### PR TITLE
feat(kcl-tekton-pr): consume Crossplane EnvironmentConfig defaults

### DIFF
--- a/kcl/ansible/CLAUDE.md
+++ b/kcl/ansible/CLAUDE.md
@@ -1,0 +1,89 @@
+# CLAUDE.md — KCL module `kcl-tekton-pr`
+
+Context for working on this KCL module with Claude Code.
+
+## What & where
+- This directory is the KCL module **`kcl-tekton-pr`** (`kcl.mod`: package
+  name `kcl-tekton-pr`, edition `v0.11.2`, entry `main.k`, dependency
+  `tekton-pipelines = "1.0.0"`).
+- Purpose: render a Tekton **PipelineRun** (for running Ansible playbooks)
+  from an `AnsibleRun`-shaped input, optionally wrapped in a
+  `kubernetes.m.crossplane.io/v1alpha1` **Object** (provider-kubernetes) so
+  Crossplane applies it on a target cluster.
+- Published manually to `oci://ghcr.io/stuttgart-things/kcl-tekton-pr`
+  (the OCI tag = `version` in `kcl.mod`). There is **no** CI that publishes
+  it — see "Publish" below.
+- Files: `main.k` (logic), `schema.k`, `defaults.k`, `values.k`, `vars.k`,
+  `README.md`.
+
+## Invocation contract (two modes)
+`main.k` reads `option("params")` and supports both:
+
+- **Composition mode** (driven by `function-kcl`): inputs are
+  `params.oxr.spec` (the XR spec), `params.ctx["apiextensions.crossplane.io/environment"]`
+  (EnvironmentConfig data merged by `function-environment-configs`),
+  `params.ocds` (observed composed resources), `params.dxr` (desired XR).
+  Output: `items = [...]`.
+- **Flat / `-D` mode** (local runs): `-D key=value` overrides, no `oxr`.
+  Output: a single resource.
+
+Per-field resolution precedence (see the `_x = _flat_params?.x or _env?.x
+or option("x") or <default>` chains in `main.k`):
+
+```
+oxr.spec.<field>  →  EnvironmentConfig (_env)  →  -D option  →  hardcoded default
+```
+
+EnvironmentConfig provides shared *defaults* only (XR spec always wins) for:
+`gitRepoUrl`, `gitRevision`, `gitPath`, `storageClass`, `ansibleWorkingImage`,
+`namespace`, `ansibleExtraCollections`, `ansibleCredentialsSecretName`.
+
+## Opt-in readiness
+`deriveReadiness` (default `false`): when true, the wrapped Object gets
+`spec.readiness.policy: DeriveFromCelQuery` so it reports `Ready` only once
+the PipelineRun's `Succeeded` condition is `True`. Keep it opt-in — other
+consumers of this module rely on the default "ready on create".
+
+## Local render / test
+```bash
+# Flat mode (fast iteration):
+kcl run main.k \
+  -D ansiblePlaybooks='["sthings.baseos.setup"]' \
+  -D ansibleVarsInventory='["all+[\"10.0.0.1\"]"]' \
+  -D wrapInCrossplane=true
+
+# Simulate composition mode (oxr + ctx + ocds):
+kcl run main.k -D params='{
+  "oxr": {"spec": {"pipelineRunName":"t","namespace":"tekton-ci",
+                   "ansiblePlaybooks":["sthings.baseos.setup"],
+                   "deriveReadiness":true}},
+  "ctx": {"apiextensions.crossplane.io/environment": {"gitRevision":"dev"}},
+  "ocds": {}
+}'
+```
+Always run a render before bumping the version — `kcl` is the source of
+truth for whether the module is valid.
+
+## Publish (manual)
+```bash
+# kcl.mod must already carry the target version.
+kcl mod push oci://ghcr.io/stuttgart-things/kcl-tekton-pr
+```
+
+## Consumer
+`stuttgart-things/crossplane-configurations` → `cicd/ansible-run`:
+- The Composition step `render-pipelinerun` pins a specific tag of this
+  module (`oci://...kcl-tekton-pr:<version>`).
+- A separate inline `function-kcl` step (`derive-status`) reads `ocds` and
+  patches the `AnsibleRun` status from the live PipelineRun; then
+  `function-auto-ready` runs.
+- **The pinned version must be published** or the Configuration's `verify`
+  CI fails with `failed to resolve <v>: ...kcl-tekton-pr:<v>: not found`.
+  So: bump `kcl.mod` → `kcl mod push` → bump the pin in the consumer.
+
+## Notes / limitations
+- The `derive-status` logic lives in the **consumer** Composition, not in
+  this module. Keep rendering concerns here; keep status-mapping there.
+- Per-TaskRun status is not available from the PipelineRun's
+  `childReferences` (only `name` + `pipelineTaskName`); surfacing per-TaskRun
+  success would require observing the TaskRun objects too.

--- a/kcl/ansible/CLAUDE.md
+++ b/kcl/ansible/CLAUDE.md
@@ -44,6 +44,12 @@ EnvironmentConfig provides shared *defaults* only (XR spec always wins) for:
 the PipelineRun's `Succeeded` condition is `True`. Keep it opt-in — other
 consumers of this module rely on the default "ready on create".
 
+**`deriveReadiness` only takes effect together with `wrapInCrossplane=true`.**
+The readiness policy lives in the Crossplane `Object` wrapper (`main.k`,
+`if _deriveReadiness:` block), which is only emitted when `wrapInCrossplane`
+is true. With `wrapInCrossplane` false (a bare `PipelineRun`), setting
+`deriveReadiness:true` is a silent no-op.
+
 ## Local render / test
 ```bash
 # Flat mode (fast iteration):
@@ -56,6 +62,7 @@ kcl run main.k \
 kcl run main.k -D params='{
   "oxr": {"spec": {"pipelineRunName":"t","namespace":"tekton-ci",
                    "ansiblePlaybooks":["sthings.baseos.setup"],
+                   "wrapInCrossplane":true,
                    "deriveReadiness":true}},
   "ctx": {"apiextensions.crossplane.io/environment": {"gitRevision":"dev"}},
   "ocds": {}

--- a/kcl/ansible/README.md
+++ b/kcl/ansible/README.md
@@ -212,3 +212,12 @@ is selected (or in flat `-D` mode) the context is empty and behaviour is
 unchanged. See the `ansible-run` Configuration in
 [`crossplane-configurations`](https://github.com/stuttgart-things/crossplane-configurations)
 for the wired-up Composition and example `EnvironmentConfig`.
+
+## READINESS (OPT-IN)
+
+Set `deriveReadiness=true` (XR `spec.deriveReadiness` or `-D`) to make the
+wrapped `Object` report `Ready` only once the PipelineRun's `Succeeded`
+condition is `True`. This is implemented via provider-kubernetes
+`spec.readiness.policy: DeriveFromCelQuery`, so `function-auto-ready` can
+bubble real pipeline success up to the XR. Default is `false` — the
+Object is ready on create, unchanged for existing consumers.

--- a/kcl/ansible/README.md
+++ b/kcl/ansible/README.md
@@ -183,3 +183,32 @@ kcl run oci://ghcr.io/stuttgart-things/kcl-tekton-pr --tag 0.4.2 -D params='{
 ```
 
 </details>
+
+## CROSSPLANE ENVIRONMENTCONFIG (SHARED DEFAULTS)
+
+When this module is rendered by `function-kcl` inside a Crossplane
+Composition, it reads shared per-environment defaults from the pipeline
+**context** key `apiextensions.crossplane.io/environment`. That key is
+populated by [`function-environment-configs`](https://github.com/crossplane-contrib/function-environment-configs),
+which must run as an earlier pipeline step and select one or more
+`EnvironmentConfig` resources.
+
+The following `data` keys are consumed (all optional):
+
+| EnvironmentConfig `data` key | Purpose |
+|------------------------------|---------|
+| `gitRepoUrl`                 | Default Git repo for the pipeline definition |
+| `gitRevision`                | Default Git branch/revision |
+| `gitPath`                    | Default path to the pipeline file in the repo |
+| `storageClass`               | Default workspace PVC StorageClass |
+| `ansibleWorkingImage`        | Default Ansible working container image |
+| `namespace`                  | Default Tekton namespace for the PipelineRun |
+| `ansibleExtraCollections`    | Default Ansible collections (JSON list) |
+| `ansibleCredentialsSecretName` | Default credentials Secret name |
+
+Precedence per field: explicit `oxr.spec` value → `EnvironmentConfig`
+value → flat `-D` option → hardcoded default. When no EnvironmentConfig
+is selected (or in flat `-D` mode) the context is empty and behaviour is
+unchanged. See the `ansible-run` Configuration in
+[`crossplane-configurations`](https://github.com/stuttgart-things/crossplane-configurations)
+for the wired-up Composition and example `EnvironmentConfig`.

--- a/kcl/ansible/kcl.mod
+++ b/kcl/ansible/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-tekton-pr"
 edition = "v0.11.2"
-version = "0.5.0"
+version = "0.6.0"
 
 [dependencies]
 tekton-pipelines = "1.0.0"

--- a/kcl/ansible/kcl.mod
+++ b/kcl/ansible/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-tekton-pr"
 edition = "v0.11.2"
-version = "0.4.6"
+version = "0.5.0"
 
 [dependencies]
 tekton-pipelines = "1.0.0"

--- a/kcl/ansible/main.k
+++ b/kcl/ansible/main.k
@@ -44,6 +44,11 @@ _crossplaneObjectName = _flat_params?.crossplaneObjectName or option("crossplane
 _crossplaneNamespace = _flat_params?.crossplaneNamespace or option("crossplaneNamespace") or "default"
 _crossplaneProviderConfig = _flat_params?.crossplaneProviderConfig or option("crossplaneProviderConfig") or "kubernetes-provider"
 _crossplaneTimeout = _flat_params?.crossplaneTimeout or option("crossplaneTimeout") or "60"
+# Opt-in: when true the wrapped Object only reports Ready once the
+# PipelineRun's "Succeeded" condition is True (via provider-kubernetes
+# DeriveFromCelQuery). Off by default so other consumers of this module
+# keep the "ready on create" behaviour.
+_deriveReadiness = _flat_params?.deriveReadiness or option("deriveReadiness") or False
 
 # --- Generate timestamp and suffix ---
 _timestamp = str(datetime.now())
@@ -126,6 +131,11 @@ _crossplaneObject = {
             kind = "ClusterProviderConfig"
             name = _crossplaneProviderConfig
         }
+        if _deriveReadiness:
+            readiness = {
+                policy = "DeriveFromCelQuery"
+                celQuery = "has(object.status) && has(object.status.conditions) && object.status.conditions.exists(c, c.type == \"Succeeded\" && c.status == \"True\")"
+            }
     }
 }
 

--- a/kcl/ansible/main.k
+++ b/kcl/ansible/main.k
@@ -12,21 +12,31 @@ _spec = _params?.oxr?.spec or {}
 # If no nested structure, use flat parameters directly
 _flat_params = _spec if _spec else _params
 
+# --- Crossplane EnvironmentConfig context ---
+# `function-environment-configs` merges the `data` of the selected
+# EnvironmentConfig(s) into the pipeline context under this well-known
+# key. The values act as shared, per-environment defaults: precedence is
+# explicit XR spec value -> EnvironmentConfig -> flat -D option ->
+# hardcoded default. When no EnvironmentConfig is selected (or when
+# running in flat/-D mode) `_env` is empty and behaviour is unchanged.
+_env = _params?.ctx?["apiextensions.crossplane.io/environment"] or {}
+
 # --- Extract fields from spec (with fallbacks to direct options for backward compatibility) ---
 _storageSize = _flat_params?.storageSize or option("storageSize") or "20Mi"
 _storageAccessModes = _flat_params?.storageAccessModes or option("storageAccessModes") or "ReadWriteOnce"
-_storageClass = _flat_params?.storageClass or option("storageClass") or "openebs-hostpath"
-_namespace = _flat_params?.namespace or option("namespace") or "tekton-ci"
+_storageClass = _flat_params?.storageClass or _env?.storageClass or option("storageClass") or "openebs-hostpath"
+_namespace = _flat_params?.namespace or _env?.namespace or option("namespace") or "tekton-ci"
 _pipelineRunName = _flat_params?.pipelineRunName or option("pipelineRunName") or None
-_gitRepoUrl = _flat_params?.gitRepoUrl or option("gitRepoUrl") or "https://github.com/stuttgart-things/stage-time.git"
-_gitRevision = _flat_params?.gitRevision or option("gitRevision") or "main"
-_gitPath = _flat_params?.gitPath or option("gitPath") or "pipelines/execute-ansible-playbooks-from-collections.yaml"
-_ansibleWorkingImage = _flat_params?.ansibleWorkingImage or option("ansibleWorkingImage") or "ghcr.io/stuttgart-things/sthings-ansible:11.11.0"
+_gitRepoUrl = _flat_params?.gitRepoUrl or _env?.gitRepoUrl or option("gitRepoUrl") or "https://github.com/stuttgart-things/stage-time.git"
+_gitRevision = _flat_params?.gitRevision or _env?.gitRevision or option("gitRevision") or "main"
+_gitPath = _flat_params?.gitPath or _env?.gitPath or option("gitPath") or "pipelines/execute-ansible-playbooks-from-collections.yaml"
+_ansibleWorkingImage = _flat_params?.ansibleWorkingImage or _env?.ansibleWorkingImage or option("ansibleWorkingImage") or "ghcr.io/stuttgart-things/sthings-ansible:11.11.0"
 _ansiblePlaybooks = _flat_params?.ansiblePlaybooks or option("ansiblePlaybooks") or ["sthings.baseos.setup"]
-_ansibleExtraCollections = _flat_params?.ansibleExtraCollections or option("ansibleExtraCollections") or []
+_ansibleExtraCollections = _flat_params?.ansibleExtraCollections or _env?.ansibleExtraCollections or option("ansibleExtraCollections") or []
 _ansibleExtraRoles = _flat_params?.ansibleExtraRoles or option("ansibleExtraRoles") or []
 _ansibleVarsInventory = _flat_params?.ansibleVarsInventory or option("ansibleVarsInventory") or []
 _ansibleVarsFile = _flat_params?.ansibleVarsFile or option("ansibleVarsFile") or []
+_ansibleCredentialsSecretName = _flat_params?.ansibleCredentialsSecretName or _env?.ansibleCredentialsSecretName or option("ansibleCredentialsSecretName") or "ansible-credentials"
 
 # --- Crossplane wrapper settings ---
 _wrapInCrossplane = _flat_params?.wrapInCrossplane or option("wrapInCrossplane") or False
@@ -70,6 +80,7 @@ _pipeline_params_override = {
     ansibleVarsInventory = _ansibleVarsInventory
     ansibleVarsFile = _ansibleVarsFile
     ansibleWorkingImage = _ansibleWorkingImage
+    ansibleCredentialsSecretName = _ansibleCredentialsSecretName
     gitRepoUrl = _gitRepoUrl
     gitRevision = _gitRevision
 }


### PR DESCRIPTION
## What

Lets the `kcl-tekton-pr` KCL module (`kcl/ansible/`) consume shared per-environment defaults from a Crossplane `EnvironmentConfig`.

When rendered by `function-kcl` inside a Composition, the module now reads the pipeline context key `apiextensions.crossplane.io/environment` (populated by `function-environment-configs`) and uses those values as defaults.

**Precedence per field:** XR spec value → EnvironmentConfig → flat `-D` option → hardcoded default.

**Consumed keys:** `gitRepoUrl`, `gitRevision`, `gitPath`, `storageClass`, `ansibleWorkingImage`, `namespace`, `ansibleExtraCollections`, `ansibleCredentialsSecretName`.

## Changes

- `kcl/ansible/main.k`: read `_env` from the context; fold it into the resolution chains of the fields above. Also wire `ansibleCredentialsSecretName` into the rendered PipelineRun params (it was not propagated in Composition mode before — small pre-existing gap fixed).
- `kcl/ansible/kcl.mod`: bump module `0.4.6` → `0.5.0`.
- `kcl/ansible/README.md`: document the EnvironmentConfig context contract.

## Backward compatibility

When no EnvironmentConfig is selected (or in flat `-D` mode), `_env` is empty and behaviour is unchanged.

## ⚠️ Follow-up

After merge, the module must be published so the consuming Composition can resolve it:

```bash
kcl mod push oci://ghcr.io/stuttgart-things/kcl-tekton-pr
```

The matching Composition change lives in `stuttgart-things/crossplane-configurations` (branch `claude/kcl-crossplane-env-config-FxraM`), which pins `kcl-tekton-pr:0.5.0`.

## Note

`kcl` was not installable in the build container (no network), so this was validated by review only — no local `kcl run`. A render check before merge is recommended.

https://claude.ai/code/session_012cJ8gpDDNtkUvvP2ermwqf

---
_Generated by [Claude Code](https://claude.ai/code/session_012cJ8gpDDNtkUvvP2ermwqf)_