### PR TITLE
fix(ansible): wire verbosity/validate params, align image defaults, drop dead param

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,10 @@ spec:
       value: all
     - name: ansibleWorkingImage
       value: ghcr.io/stuttgart-things/sthings-ansible:11.11.0
+    - name: ansibleVerbosity
+      value: "2"
+    - name: validateInventory
+      value: "true"
     # Collections
     - name: ansibleExtraCollections
       value:

--- a/pipelines/execute-ansible-playbooks-from-collections.yaml
+++ b/pipelines/execute-ansible-playbooks-from-collections.yaml
@@ -24,6 +24,16 @@ spec:
       type: string
       default: "ghcr.io/stuttgart-things/sthings-ansible:11.11.0"
 
+    - name: ansibleVerbosity
+      type: string
+      default: "2"
+      description: ansible verbosity level (0-4, where 0 is minimal)
+
+    - name: validateInventory
+      type: string
+      default: "true"
+      description: validate inventory before running playbooks
+
     - name: ansibleExtraCollections
       type: array
       default: []
@@ -134,6 +144,12 @@ spec:
 
         - name: WORKING_IMAGE
           value: $(params.ansibleWorkingImage)
+
+        - name: ANSIBLE_VERBOSITY
+          value: $(params.ansibleVerbosity)
+
+        - name: VALIDATE_INVENTORY
+          value: $(params.validateInventory)
 
         - name: vault-secret-name
           value: $(params.vaultSecretName)

--- a/pipelines/execute-ansible-playbooks.yaml
+++ b/pipelines/execute-ansible-playbooks.yaml
@@ -17,10 +17,6 @@ spec:
       type: array
       default: []
       description: extra collections to install
-    - name: ansibleInventoryFile
-      type: array
-      default: []
-      description: values for ansible inventory file
     - name: ansiblePlaybooks
       type: array
       default: []
@@ -45,6 +41,14 @@ spec:
       type: string
       default: "ghcr.io/stuttgart-things/sthings-ansible:11.11.0"
       description: the image on which ansible will run
+    - name: ansibleVerbosity
+      type: string
+      default: "2"
+      description: ansible verbosity level (0-4, where 0 is minimal)
+    - name: validateInventory
+      type: string
+      default: "true"
+      description: validate inventory before running playbooks
     - name: createInventory
       type: string
       default: "false"
@@ -139,6 +143,10 @@ spec:
           value: $(params.userHome)
         - name: WORKING_IMAGE
           value: $(params.ansibleWorkingImage)
+        - name: ANSIBLE_VERBOSITY
+          value: $(params.ansibleVerbosity)
+        - name: VALIDATE_INVENTORY
+          value: $(params.validateInventory)
         - name: vault-secret-name
           value: $(params.vaultSecretName)
         # Add the new parameters for ansible credentials

--- a/tasks/execute-ansible.yaml
+++ b/tasks/execute-ansible.yaml
@@ -72,7 +72,7 @@ spec:
     - name: WORKING_IMAGE
       description: the image on which ansible will run
       type: string
-      default: "eu.gcr.io/stuttgart-things/sthings-ansible:11.0.0"
+      default: "ghcr.io/stuttgart-things/sthings-ansible:11.11.0"
     - name: ANSIBLE_VERBOSITY
       description: ansible verbosity level (0-4, where 0 is minimal)
       type: string

--- a/tests/ansible-pr.yaml
+++ b/tests/ansible-pr.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   params:
   - name: ansibleWorkingImage
-    value: ghcr.io/stuttgart-things/sthings-ansible:11.0.0
+    value: ghcr.io/stuttgart-things/sthings-ansible:11.11.0
   - name: createInventory
     value: "false"
   - name: ansibleTargetHost

--- a/tests/pr.yaml
+++ b/tests/pr.yaml
@@ -17,7 +17,7 @@ spec:
     resolver: git
   params:
   - name: ansibleWorkingImage
-    value: ghcr.io/stuttgart-things/sthings-ansible:11.0.0
+    value: ghcr.io/stuttgart-things/sthings-ansible:11.11.0
   - name: createInventory
     value: "false"
   - name: gitRepoUrl


### PR DESCRIPTION
First batch of low-risk fixes from the Ansible review tracked in #34.

## Changes

**Pipelines — `pipelines/execute-ansible-playbooks.yaml` + `...-from-collections.yaml`**
- Declare and wire `ansibleVerbosity` → `ANSIBLE_VERBOSITY` and `validateInventory` → `VALIDATE_INVENTORY`. These Task params existed but were never exposed by the pipelines, so the README/test examples passing them were silent no-ops.
- Remove the unused `ansibleInventoryFile` param (declared, never passed to any task).

**Task — `tasks/execute-ansible.yaml`**
- Default image `eu.gcr.io/stuttgart-things/sthings-ansible:11.0.0` → `ghcr.io/stuttgart-things/sthings-ansible:11.11.0`. GCR is end-of-life, and this now matches the pipeline default.

**Docs / examples**
- Bump stale `11.0.0` images in `tests/ansible-pr.yaml` and `tests/pr.yaml`.
- Document `ansibleVerbosity` / `validateInventory` in the README collections example (the git example already had them).

## Scope / not in this PR
The deeper items (POSIX-`sh` vs bash shebang, the `+-` var DSL, `eval`, `main`-pinned resolvers, scratch-file "tests", and the KCL findings — dropped composition-mode params, the `storageAccessModes` schema bug, etc.) are intentionally left for follow-up. They're all enumerated in #34 to be done one by one.

Part of #34

https://claude.ai/code/session_01XMZZG1kxJe7KtZEnsyjaDW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMZZG1kxJe7KtZEnsyjaDW)_