### PR TITLE
ci: add pre-commit and KCL validation workflows

### DIFF
--- a/.github/workflows/kcl-validate.yaml
+++ b/.github/workflows/kcl-validate.yaml
@@ -1,0 +1,30 @@
+---
+name: KCL Validate
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  kcl-validate:
+    name: KCL Validate
+    strategy:
+      fail-fast: false
+      matrix:
+        module-dir:
+          - kcl/ansible
+          - kcl/ansible-run
+          - kcl/buildah
+    # NOTE: requires call-kcl-validate.yaml to be merged into
+    # github-workflow-templates' main branch first.
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-kcl-validate.yaml@main
+    with:
+      module-dir: ${{ matrix.module-dir }}
+    secrets: inherit

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,0 +1,21 @@
+---
+name: Pre-commit
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  pre-commit:
+    name: Pre-commit Hooks
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-pre-commit.yaml@main
+    with:
+      config-path: .pre-commit-config.yaml
+    secrets: inherit


### PR DESCRIPTION
## What

Add the first CI for this repo as thin callers into the org reusable workflows in `stuttgart-things/github-workflow-templates` (addresses the CI / GitHub Actions section of #34):

- **`.github/workflows/pre-commit.yaml`** → `call-pre-commit.yaml@main` — runs the repo's existing `.pre-commit-config.yaml` in CI (YAML/whitespace/EOF, `detect-secrets` + `detect-private-key`, `hadolint`, `check-github-workflows`).
- **`.github/workflows/kcl-validate.yaml`** → `call-kcl-validate.yaml@main` — matrix over `kcl/ansible`, `kcl/ansible-run`, `kcl/buildah`: `kcl fmt` check + compile/render check.

Both run on `pull_request: [opened, reopened, synchronize]` + `workflow_dispatch`, with concurrency cancellation and `secrets: inherit`.

## Notes

- The KCL template (`stuttgart-things/github-workflow-templates#116`) is already merged to `main`, so the caller resolves.
- **Tekton validation is intentionally not included** — there is no Dagger module that kubeconforms raw Tekton manifests (`helm.Kubeconform` renders a chart first; `tasks/`/`pipelines/` are raw Task/Pipeline YAML). Tracked in #34; a `dagger` module will be authored first, then `call-tekton-validate.yaml` + a caller added.
- Follow-up (#34, decision 3): gate merges via branch protection on `Pre-commit Hooks` and the `KCL Validate (*)` jobs once verified green.

https://claude.ai/code/session_01KLjXXpPmBZyv8S63Ky7odj

---
_Generated by [Claude Code](https://claude.ai/code/session_01KLjXXpPmBZyv8S63Ky7odj)_