### PR TITLE
fix(kcl/ansible): honour composition-mode params & fix storageAccessModes set

### DIFF
--- a/kcl/ansible/main.k
+++ b/kcl/ansible/main.k
@@ -36,6 +36,7 @@ _ansibleExtraRoles = _flat_params?.ansibleExtraRoles or option("ansibleExtraRole
 _ansibleVarsInventory = _flat_params?.ansibleVarsInventory or option("ansibleVarsInventory") or []
 _ansibleVarsFile = _flat_params?.ansibleVarsFile or option("ansibleVarsFile") or []
 _ansibleCredentialsSecretName = _flat_params?.ansibleCredentialsSecretName or _env?.ansibleCredentialsSecretName or option("ansibleCredentialsSecretName") or "ansible-credentials"
+
 # Previously these only resolved from `-D` options via values.k, so setting
 # them in an XR spec (composition mode) was silently ignored. Extract them
 # here so `oxr.spec.<field>` is honoured, same precedence as the fields above.

--- a/kcl/ansible/main.k
+++ b/kcl/ansible/main.k
@@ -36,6 +36,22 @@ _ansibleExtraRoles = _flat_params?.ansibleExtraRoles or option("ansibleExtraRole
 _ansibleVarsInventory = _flat_params?.ansibleVarsInventory or option("ansibleVarsInventory") or []
 _ansibleVarsFile = _flat_params?.ansibleVarsFile or option("ansibleVarsFile") or []
 _ansibleCredentialsSecretName = _flat_params?.ansibleCredentialsSecretName or _env?.ansibleCredentialsSecretName or option("ansibleCredentialsSecretName") or "ansible-credentials"
+# Previously these only resolved from `-D` options via values.k, so setting
+# them in an XR spec (composition mode) was silently ignored. Extract them
+# here so `oxr.spec.<field>` is honoured, same precedence as the fields above.
+_ansibleCredentialsUserKey = _flat_params?.ansibleCredentialsUserKey or option("ansibleCredentialsUserKey") or "ANSIBLE_USER"
+_ansibleCredentialsPasswordKey = _flat_params?.ansibleCredentialsPasswordKey or option("ansibleCredentialsPasswordKey") or "ANSIBLE_PASSWORD"
+_createInventory = _flat_params?.createInventory or option("createInventory") or "true"
+_ansibleTargetHost = _flat_params?.ansibleTargetHost or option("ansibleTargetHost") or "all"
+_gitWorkspaceSubdirectory = _flat_params?.gitWorkspaceSubdirectory or option("gitWorkspaceSubdirectory") or "/ansible/workdir/"
+_installExtraRoles = _flat_params?.installExtraRoles or option("installExtraRoles") or "true"
+_installExtraCollections = _flat_params?.installExtraCollections or option("installExtraCollections") or "true"
+_userHome = _flat_params?.userHome or option("userHome") or "/home/nonroot"
+_vaultSecretName = _flat_params?.vaultSecretName or option("vaultSecretName") or "vault"
+_inventory = _flat_params?.inventory or option("inventory") or ""
+_varsFile = _flat_params?.varsFile or option("varsFile") or ""
+_ansibleVerbosity = _flat_params?.ansibleVerbosity or option("ansibleVerbosity") or "2"
+_validateInventory = _flat_params?.validateInventory or option("validateInventory") or "true"
 
 # --- Crossplane wrapper settings ---
 _wrapInCrossplane = _flat_params?.wrapInCrossplane or option("wrapInCrossplane") or False
@@ -86,6 +102,19 @@ _pipeline_params_override = {
     ansibleVarsFile = _ansibleVarsFile
     ansibleWorkingImage = _ansibleWorkingImage
     ansibleCredentialsSecretName = _ansibleCredentialsSecretName
+    ansibleCredentialsUserKey = _ansibleCredentialsUserKey
+    ansibleCredentialsPasswordKey = _ansibleCredentialsPasswordKey
+    createInventory = _createInventory
+    ansibleTargetHost = _ansibleTargetHost
+    gitWorkspaceSubdirectory = _gitWorkspaceSubdirectory
+    installExtraRoles = _installExtraRoles
+    installExtraCollections = _installExtraCollections
+    userHome = _userHome
+    vaultSecretName = _vaultSecretName
+    inventory = _inventory
+    varsFile = _varsFile
+    ansibleVerbosity = _ansibleVerbosity
+    validateInventory = _validateInventory
     gitRepoUrl = _gitRepoUrl
     gitRevision = _gitRevision
 }

--- a/kcl/ansible/schema.k
+++ b/kcl/ansible/schema.k
@@ -25,7 +25,7 @@ schema StorageConfig:
         # Validate storage size format (e.g., "20Mi", "1Gi")
         storageSize.endswith("Mi") or storageSize.endswith("Gi") if storageSize, "storageSize must end with 'Mi' or 'Gi'"
         # Validate access modes
-        storageAccessModes in ["ReadWriteOnce", "ReadWriteOnce", "ReadOnlyMany"] if storageAccessModes, "Invalid storage access mode"
+        storageAccessModes in ["ReadWriteOnce", "ReadWriteMany", "ReadOnlyMany"] if storageAccessModes, "Invalid storage access mode"
 
 schema PipelineOverrides:
     """


### PR DESCRIPTION
Second batch from the review tracked in #34 — the KCL bugs in `kcl/ansible` (`kcl-tekton-pr`).

## Changes

**`main.k` — composition-mode params silently dropped**
`main.k` only extracted a subset of fields from `oxr.spec`; the rest resolved *only* from `-D` options via `values.k`, so setting them in an **XR spec** (composition mode) was a no-op. Now extracted in `main.k` and added to `_pipeline_params_override` (the highest-precedence layer) so `oxr.spec` wins, with the same `_flat_params?.x or option(...) or <default>` precedence as the existing fields:
`createInventory`, `ansibleTargetHost`, `gitWorkspaceSubdirectory`, `installExtraRoles`, `installExtraCollections`, `userHome`, `vaultSecretName`, `inventory`, `varsFile`, `ansibleCredentialsUserKey`, `ansibleCredentialsPasswordKey`.

Also forwards **`ansibleVerbosity` / `validateInventory`**, which the pipelines accept (since #35) but this module never emitted.

**`schema.k` — `storageAccessModes` allow-list**
Listed `ReadWriteOnce` twice and omitted `ReadWriteMany`; corrected to `["ReadWriteOnce", "ReadWriteMany", "ReadOnlyMany"]`.

## Verification
`kcl` 0.12.3 render (the tekton-pipelines OCI dep isn't reachable from CI's network, so I rendered the dependency-free `vars`/`values`/`defaults`/`schema` chain with a harness mirroring `main.k`'s extraction+merge):
- **Flat mode:** defaults unchanged; `ansibleVerbosity`/`validateInventory` now present.
- **Composition mode** (`oxr.spec` overrides): `createInventory`, `installExtraRoles`, `ansibleVerbosity`, `userHome`, `ansibleTargetHost` all reflect the spec values — previously dropped.

## Note
This closes the "composition-mode params dropped", "verbosity/validate not emitted", and "storageAccessModes schema" items in #34. The `createInventory` default is now single-sourced in `main.k` (`"true"`), so the dead `defaults.k`/`values.k` divergence is moot — I left the cosmetic `defaults.k` cleanup and the `kcl/ansible-run` consolidation as separate #34 items.

Part of #34

https://claude.ai/code/session_01XMZZG1kxJe7KtZEnsyjaDW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMZZG1kxJe7KtZEnsyjaDW)_