### PR TITLE
fix(pipelines): pin external git-clone dep; add step resource requests

### DIFF
--- a/pipelines/execute-ansible-playbooks.yaml
+++ b/pipelines/execute-ansible-playbooks.yaml
@@ -162,8 +162,12 @@ spec:
         params:
           - name: url
             value: https://github.com/tektoncd/catalog.git
+          # Pinned to a fixed commit for reproducibility/supply-chain safety
+          # (external dependency). tektoncd/catalog main @ 2026-06; bump
+          # deliberately. The stage-time self-reference above stays on `main`
+          # so local task edits still auto-propagate.
           - name: revision
-            value: main
+            value: 7ea2968e224633b4967d60217b33bb4d38fa53d9
           - name: pathInRepo
             value: task/git-clone/0.10/git-clone.yaml
       workspaces:

--- a/pipelines/execute-ansible-playbooks.yaml
+++ b/pipelines/execute-ansible-playbooks.yaml
@@ -167,7 +167,7 @@ spec:
           # deliberately. The stage-time self-reference above stays on `main`
           # so local task edits still auto-propagate.
           - name: revision
-            value: 7ea2968e224633b4967d60217b33bb4d38fa53d9
+            value: 7ea2968e224633b4967d60217b33bb4d38fa53d9 # pragma: allowlist secret (git commit SHA, not a secret)
           - name: pathInRepo
             value: task/git-clone/0.10/git-clone.yaml
       workspaces:

--- a/tasks/execute-ansible.yaml
+++ b/tasks/execute-ansible.yaml
@@ -123,6 +123,13 @@ spec:
       privileged: false
       runAsNonRoot: true
       runAsUser: 65532
+    # Requests only (no limits): give the scheduler sizing info without
+    # capping the variable footprint of ansible runs / galaxy installs,
+    # which a too-low memory limit could OOM-kill.
+    computeResources:
+      requests:
+        cpu: 250m
+        memory: 256Mi
   steps:
     - name: create-inventory-vars
       args:


### PR DESCRIPTION
The "Pipelines" cluster from #34. Two changes, per the agreed approach (pin external deps only; requests-only resources).

## Changes

**Pin the external git-clone dependency** (`pipelines/execute-ansible-playbooks.yaml`)
The `fetch-repository` step resolved `tektoncd/catalog` git-clone at `revision: main` — a moving external dependency. Pinned it to a fixed commit (`7ea2968e224633b4967d60217b33bb4d38fa53d9`, catalog `main` HEAD as of 2026-06, obtained via `git ls-remote`). The **stage-time self-reference** (the `execute-ansible` taskRef) intentionally **stays on `main`** so local task edits keep auto-propagating — that was a deliberate call to avoid a SHA-bump-per-edit workflow.

**Requests-only step resources** (`tasks/execute-ansible.yaml`)
Added `computeResources.requests` (cpu `250m`, memory `256Mi`) to the `stepTemplate` — gives the scheduler sizing info. Deliberately **no limits**: a too-low memory limit would risk OOM-killing the variable footprint of ansible runs / galaxy collection installs.

## Scope notes
- `pipelines/build-image-buildah.yaml` has the same `revision: main` pattern for its external taskRefs but is outside the ansible review scope; left untouched (can be a follow-up if you want the same treatment).
- The catalog pin is a manual bump (Renovate doesn't track git-resolver revisions in arbitrary YAML); noted in an in-line comment.

Both files validated (`yaml.safe_load_all`). `computeResources` is the correct field for `tekton.dev/v1`.

Part of #34

https://claude.ai/code/session_01XMZZG1kxJe7KtZEnsyjaDW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMZZG1kxJe7KtZEnsyjaDW)_