### PR TITLE
chore: pin buildah catalog dep; align kcl README tag to 0.6.0

### DIFF
--- a/kcl/ansible/README.md
+++ b/kcl/ansible/README.md
@@ -15,7 +15,7 @@ kcl mod push oci://ghcr.io/stuttgart-things/kcl-tekton-pr
 <details><summary>EXAMPLE RENDERING</summary>
 
 ```bash
-kcl run oci://ghcr.io/stuttgart-things/kcl-tekton-pr --tag 0.3.0 \
+kcl run oci://ghcr.io/stuttgart-things/kcl-tekton-pr --tag 0.6.0 \
   -D storageSize="5000Mi" \
   -D storageAccessModes="ReadWriteOnce" \
   -D ansiblePlaybooks='["sthings.baseos.prepare_env", "sthings.baseos.setup", "sthings.apps.deploy"]' \
@@ -28,7 +28,7 @@ kcl run oci://ghcr.io/stuttgart-things/kcl-tekton-pr --tag 0.3.0 \
 
 ```bash
 # RENDER + APPLY
-kcl run oci://ghcr.io/stuttgart-things/kcl-tekton-pr --tag 0.3.0 \
+kcl run oci://ghcr.io/stuttgart-things/kcl-tekton-pr --tag 0.6.0 \
 -D pipelineRunName="run-ansible-test-6" \
 -D namespace="tekton-ci" \
 -D storageSize="20Mi" \
@@ -103,7 +103,7 @@ kcl run ./main.k \
 
 ```bash
 # RENDER (# or use main.k (or leave out reference) instead of the oci module)
-kcl run oci://ghcr.io/stuttgart-things/kcl-tekton-pr --tag 0.4.3 -D params='{
+kcl run oci://ghcr.io/stuttgart-things/kcl-tekton-pr --tag 0.6.0 -D params='{
   "oxr": {
     "spec": {
       "pipelineRunName": "run-ansible-test-6",
@@ -155,7 +155,7 @@ kcl run oci://ghcr.io/stuttgart-things/kcl-tekton-pr --tag 0.4.3 -D params='{
 
 ```bash
 # MINIMAL
-kcl run oci://ghcr.io/stuttgart-things/kcl-tekton-pr --tag 0.4.2 -D params='{
+kcl run oci://ghcr.io/stuttgart-things/kcl-tekton-pr --tag 0.6.0 -D params='{
   "oxr": {
     "spec": {
       "pipelineRunName": "run-ansible-test1",

--- a/pipelines/build-image-buildah.yaml
+++ b/pipelines/build-image-buildah.yaml
@@ -58,8 +58,11 @@ spec:
         params:
           - name: url
             value: https://github.com/tektoncd/catalog.git
+          # Pinned to a fixed commit for reproducibility/supply-chain safety
+          # (external dependency). tektoncd/catalog main @ 2026-06; bump
+          # deliberately. The stage-time self-reference below stays on `main`.
           - name: revision
-            value: main
+            value: 7ea2968e224633b4967d60217b33bb4d38fa53d9 # pragma: allowlist secret (git commit SHA, not a secret)
           - name: pathInRepo
             value: task/git-clone/0.10/git-clone.yaml
       workspaces:


### PR DESCRIPTION
Two quick wins from #34.

## Changes
- **Pin buildah external dep** (`pipelines/build-image-buildah.yaml`) — the `fetch-repository` step pulled `tektoncd/catalog` git-clone at `revision: main`; pinned to the same fixed commit as #40 (`7ea2968`). The stage-time **self-reference** (the `buildah` taskRef → `tasks/build-buildah.yaml`) stays on `main`, consistent with the agreed approach. SHA carries the `# pragma: allowlist secret` so detect-secrets doesn't flag it.
- **KCL README tag drift** (`kcl/ansible/README.md`) — bumped the `kcl-tekton-pr --tag` examples from `0.3.0`/`0.4.2`/`0.4.3` to **`0.6.0`** (matches `kcl.mod`). Verified `0.6.0` is actually published in ghcr (queried the registry tag list) so the examples stay runnable.

## Verification
- `build-image-buildah.yaml` parses; the catalog taskRef `revision` reads as the bare SHA, the buildah self-ref reads `main`.
- All four README `--tag` references now `0.6.0`.

Closes the "Pipelines follow-up" and "KCL README tag drift" items in #34.

Part of #34

https://claude.ai/code/session_01XMZZG1kxJe7KtZEnsyjaDW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMZZG1kxJe7KtZEnsyjaDW)_