### PR TITLE
build(images/ansible): update sthings-ansible Dockerfile to 14.0.0

### DIFF
--- a/images/ansible/Dockerfile
+++ b/images/ansible/Dockerfile
@@ -1,67 +1,57 @@
 # BASE
-FROM ghcr.io/stuttgart-things/sthings-alpine:3.13-alpine
+FROM ghcr.io/stuttgart-things/sthings-alpine:3.11.14-alpine3.23
 
 # METADATA INFORMATION
-LABEL version=12.0.0
+LABEL version=14.0.0
 LABEL maintainer="Patrick Hermann <patrick.hermann@sva.de>"
 
 # SOFTWARE
-ARG YQ_VERSION=4.47.2
-ARG ANSIBLE_VERSION=12.0.0
-ARG ANSIBLE_LINT_VERSION=25.9.1
-ARG MACHINE_SHOP_VERSION=2.6.10
+ARG YQ_VERSION=4.53.2
+ARG ANSIBLE_VERSION=14.0.0
+ARG ANSIBLE_LINT_VERSION=26.4.0
 
-# NON-ROOT USER ID AND GROUP ID
-ENV USER_ID=65532
-ENV GROUP_ID=65532
-ENV PATH="/root/.cargo/bin:${PATH}"
+# NON-ROOT USER ID AND GROUP ID + PIP HYGIENE
+ENV USER_ID=65532 \
+    GROUP_ID=65532 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_ROOT_USER_ACTION=ignore
 
-# INSTALL RUST
-RUN curl -sSf https://sh.rustup.rs | sh -s -- -y
+# RUNTIME PACKAGES (kept in the final image) + YQ.
+# libffi/openssl are the runtime shared libs for cryptography/paramiko; the
+# *-dev headers and compilers are build-only and live in the .build-deps layer.
+RUN apk add --no-cache git curl wget tar bash python3 py3-pip py3-virtualenv libffi openssl \
+    && curl -fsSL "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64" -o /usr/bin/yq \
+    && chmod +x /usr/bin/yq
 
-# INSTALL NECESSARY PACKAGES
-RUN apk add --no-cache \
-        git \
-        curl \
-        wget \
-        tar \
-        python3 \
-        py3-pip \
-        bash \
-        py3-virtualenv \
-        gcc \
-        musl-dev \
-        libffi-dev \
-        openssl-dev
+# PYTHON DEPS + ANSIBLE.
+# The whole build toolchain (gcc/musl-dev/*-dev + the Rust used to compile the
+# cryptography native extension) is installed, used, and torn down in a SINGLE
+# layer, so none of it — nor the pip/cargo/rustup caches — ships in the final
+# image. This is the main size win over the previous version, which left the
+# compilers and ~/.cargo + ~/.rustup behind.
+RUN apk add --no-cache --virtual .build-deps gcc musl-dev libffi-dev openssl-dev \
+    && curl -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal \
+    && . "$HOME/.cargo/env" \
+    && /usr/local/bin/python -m pip install --upgrade pip \
+    && pip install \
+        cryptography hvac "hvac[parser]" paramiko jmespath openshift kubernetes \
+        boto3 passlib kubernetes-validate==1.27.0 proxmoxer netaddr setuptools \
+        requests pyVim PyVmomi python-dateutil dnspython pycryptodome pywinrm pytz \
+        ansible==${ANSIBLE_VERSION} ansible-lint==${ANSIBLE_LINT_VERSION} \
+    && apk del .build-deps \
+    && rm -rf /root/.rustup /root/.cargo /root/.cache /tmp/*
 
-# SET THE PATH FOR PIPX-INSTALLED BINARIES
-ENV PATH=/root/.local/bin:$PATH
-
-# INSTALL YQ
-RUN wget -q "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64.tar.gz" \
-    && tar -xzf yq_linux_amd64.tar.gz -C /usr/bin \
-    && mv /usr/bin/yq_linux_amd64 /usr/bin/yq \
-    && chmod +x /usr/bin/yq \
-    && rm -f yq_linux_amd64.tar.gz
-
-# INSTALL MACHINESHOP
-RUN wget -q "https://github.com/stuttgart-things/machineshop/releases/download/v${MACHINE_SHOP_VERSION}/machineshop_Linux_x86_64.tar.gz" \
-    && tar -xzf machineshop_Linux_x86_64.tar.gz -C /usr/bin machineshop \
-    && chmod +x /usr/bin/machineshop \
-    && rm -f machineshop_Linux_x86_64.tar.gz
-
-# GET RUST; NOTE: USING SH FOR BETTER COMPATIBILITY WITH OTHER BASE IMAGES
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
-ENV PATH="/root/.cargo/bin:${PATH}"
-RUN /usr/local/bin/python -m pip install --upgrade pip && pip install pip --upgrade
-RUN pip install --no-cache-dir cryptography hvac "hvac[parser]" paramiko jmespath openshift kubernetes boto3 passlib kubernetes-validate==1.27.0 proxmoxer netaddr setuptools requests pyVim PyVmomi python.dateutil dnspython pycrypto pywinrm pytz ansible==${ANSIBLE_VERSION} ansible-lint==${ANSIBLE_LINT_VERSION}
+# ANSIBLE COLLECTIONS — baked from stuttgart-things/ansible `main` requirements
+# at build time into /home/nonroot/.ansible/collections (the path the runner
+# resolves at run time). NOTE: this fetches REMOTE main, so push requirement
+# changes before building. The build cache busts when main's requirements move.
 RUN mkdir -p /home/nonroot/.ansible && chown -R ${USER_ID}:${GROUP_ID} /home/nonroot/.ansible
-
-# ANSIBLE REQUIREMENTS
 USER 65532
 WORKDIR /home/nonroot/.ansible
-RUN wget --progress=dot:giga https://raw.githubusercontent.com/stuttgart-things/ansible/refs/heads/main/requirements.yaml \
-    && ansible-galaxy install -r requirements.yaml --force
+RUN curl -fsSL https://raw.githubusercontent.com/stuttgart-things/ansible/refs/heads/main/requirements.yaml -o requirements.yaml \
+    && ansible-galaxy install -r requirements.yaml --force \
+    && rm -rf /home/nonroot/.ansible/tmp
 
 USER root
 


### PR DESCRIPTION
Integrates the new `sthings-ansible` Dockerfile (`images/ansible/Dockerfile`), bumping 12.0.0 → 14.0.0.

## Changes
- **Versions:** ansible `14.0.0`, ansible-lint `26.4.0`, yq `4.53.2`; base `ghcr.io/stuttgart-things/sthings-alpine:3.11.14-alpine3.23`.
- **Layer hygiene (main win):** the full build toolchain (`gcc`/`musl-dev`/`*-dev` + rustup, used to compile the `cryptography` native ext) is installed, used and removed in a single layer, and the pip/cargo/rustup caches are deleted. The previous Dockerfile left the compilers + `~/.cargo`/`~/.rustup` in the final image. Runtime shared libs (`libffi`, `openssl`) are kept.
- **pip hygiene** via env (`PIP_NO_CACHE_DIR`, `PIP_DISABLE_PIP_VERSION_CHECK`, `PIP_ROOT_USER_ACTION`).
- Collections still baked from `stuttgart-things/ansible` `main` requirements into `/home/nonroot/.ansible`.

## Behavioral changes worth a look
- **`machineshop` is no longer installed** in the image (the 12.0.0 build baked in `machineshop` v2.6.10). If anything that runs inside this image relies on `machineshop`, that breaks. The `execute-ansible` task doesn't use it; the Taskfile's `machineshop render` runs on the dev host, not in this image — so it looks safe, but confirming with you.
- **Fixed two bad package names** from the old file: `python.dateutil` → `python-dateutil`, and `pycrypto` (dead/unmaintained) → `pycryptodome`.

## Notes
- I couldn't build it here (no Docker; it also pulls remote base + rust + galaxy reqs) — needs a real image build to validate. hadolint is skipped in CI (needs Docker in the Dagger sandbox), so this won't be auto-linted.
- **Did not** bump the consumed image version anywhere (task default, pipelines, README, KCL still reference `:11.11.0`). Those should only move to `14.0.0` once this image is actually built and pushed.

https://claude.ai/code/session_01XMZZG1kxJe7KtZEnsyjaDW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMZZG1kxJe7KtZEnsyjaDW)_