### PR TITLE
docs(kcl/ansible-run): clarify role as the AnsibleRun XR generator

### DIFF
--- a/kcl/ansible-run/README.md
+++ b/kcl/ansible-run/README.md
@@ -1,5 +1,18 @@
 # ANSIBLE-RUN
 
+> **What this is:** a **client-side generator for the `AnsibleRun` XR**
+> (`resources.stuttgart-things.com/v1alpha1`) — it renders the *request* object
+> you `kubectl apply`. It is **not** the Composition renderer; that is
+> [`kcl/ansible`](../ansible) (`kcl-tekton-pr`), which turns an `AnsibleRun`
+> spec into a Tekton `PipelineRun`.
+>
+> The **canonical schema** is the XRD in
+> [`stuttgart-things/crossplane-configurations`](https://github.com/stuttgart-things/crossplane-configurations)
+> (`cicd/ansible-run/apis/definition.yaml`). The fields this generator exposes
+> are a **subset** of it — for the full spec and authoritative examples, see
+> that XRD and `cicd/ansible-run/examples/xr*.yaml`. Restructure options are
+> tracked in [#45](https://github.com/stuttgart-things/stage-time/issues/45).
+
 ## RENDER CLAIM (KIND XPLANE SETUP)
 
 ```bash

--- a/kcl/ansible-run/main.k
+++ b/kcl/ansible-run/main.k
@@ -3,6 +3,17 @@ AnsibleRun Main Configuration
 Supports both Composition format and flat format with -D overrides
 """
 
+# kcl/ansible-run — CLIENT-SIDE GENERATOR for the AnsibleRun XR
+# (resources.stuttgart-things.com/v1alpha1).
+#
+# This renders the *request* object you `kubectl apply`. It is NOT the
+# Composition renderer — that is kcl/ansible (kcl-tekton-pr), which turns an
+# AnsibleRun spec into a Tekton PipelineRun.
+#
+# The canonical schema is the XRD in stuttgart-things/crossplane-configurations
+# (cicd/ansible-run/apis/definition.yaml). The fields below are a SUBSET; for
+# the full spec and authoritative examples see that XRD and
+# cicd/ansible-run/examples/xr*.yaml.  See stage-time#45.
 import .schema
 
 # --- Read parameters (supports both Composition format and flat format) ---


### PR DESCRIPTION
Doc-only. Implements **option A** from #45: clarifies that `kcl/ansible-run` is the **client-side generator for the `AnsibleRun` XR**, distinct from `kcl/ansible` (`kcl-tekton-pr`) which renders the `PipelineRun` inside the Composition.

## Changes
- `kcl/ansible-run/main.k` — module header explaining the role, that its field set is a **subset** of the canonical XRD (`crossplane-configurations/cicd/ansible-run/apis/definition.yaml`), and pointing at the authoritative examples + #45.
- `kcl/ansible-run/README.md` — same clarification as a blockquote under the title.

No behaviour change. Restructure (B/C/D) stays deferred in #45.

## Verification
- `kcl run main.k` still renders the `AnsibleRun` XR correctly (this module has no external deps, so verified in full offline).
- `kcl fmt` clean/idempotent; no trailing whitespace.

Closes the "document (A)" step of #45.

https://claude.ai/code/session_01XMZZG1kxJe7KtZEnsyjaDW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMZZG1kxJe7KtZEnsyjaDW)_