### PR TITLE
ci: enable hadolint in pre-commit via bundled binary (dagger v0.119.0)

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -18,8 +18,8 @@ jobs:
     uses: stuttgart-things/github-workflow-templates/.github/workflows/call-pre-commit.yaml@main
     with:
       config-path: .pre-commit-config.yaml
-      # hadolint-docker shells out to `docker`, which isn't available inside the
-      # Dagger pre-commit sandbox. Skip it here; Dockerfile linting is tracked as
-      # a follow-up in #34 (separate hadolint job or hadolint in the linting image).
-      skip-hooks: hadolint-docker
+      # v0.119.0 bundles the hadolint static binary on PATH, so the local
+      # `hadolint` (language: system) hook in .pre-commit-config.yaml runs
+      # natively in-container — no Docker needed, nothing to skip.
+      linting-module-version: v0.119.0
     secrets: inherit # pragma: allowlist secret

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,29 +15,34 @@ repos:
       - id: check-symlinks
       #- id: check-yaml
       - id: detect-private-key
-  - repo: https://github.com/hadolint/hadolint
-    rev: "v2.12.0"
+  # hadolint via the bundled static binary on PATH (provided by the dagger
+  # linting module, v0.119.0+). The upstream hadolint/hadolint hook ids
+  # (`hadolint`, `hadolint-docker`) are Docker-based and don't work inside the
+  # Dagger container — so wire a local/system hook against the binary instead.
+  - repo: local
     hooks:
-      - id: hadolint-docker
+      - id: hadolint
+        name: Lint Dockerfiles with hadolint
+        entry: hadolint
+        language: system
+        types: [dockerfile]
         args:
           - --ignore
-          - DL4006
+          - DL4006   # set -o pipefail before RUN with a pipe
           - --ignore
-          - DL3015
+          - DL3015   # avoid additional packages (--no-install-recommends)
           - --ignore
-          - DL4006   # Use absolute WORKDIR
+          - DL3018   # pin versions in apk add
           - --ignore
-          - DL3015   # Use ADD instead of COPY
+          - DL4001   # either wget or curl, not both
           - --ignore
-          - DL3018   # Pin versions in apk add
+          - DL3042   # avoid pip cache dir
           - --ignore
-          - DL4001   # Either use Wget or Curl but not both
+          - DL3013   # pin versions in pip
           - --ignore
-          - DL3042   # Avoid pip cache dir
+          - DL3002   # last USER should not be root
           - --ignore
-          - DL3013   # Pin versions in pip
-          - --ignore
-          - DL3002   # Last USER should not be root
+          - SC1091   # can't follow runtime-sourced files (e.g. cargo env)
   - repo: https://github.com/sirosen/check-jsonschema
     rev: 0.30.0
     hooks:


### PR DESCRIPTION
Enables Dockerfile linting in CI — closes the "hadolint in CI" follow-up from #34, unblocked by [stuttgart-things/dagger#302](https://github.com/stuttgart-things/dagger/pull/302) (released **v0.119.0**), which bundles the `hadolint` static binary on PATH in the linting module.

## Why it was skipped
The `.pre-commit-config.yaml` used `hadolint-docker`, which shells out to `docker run`. There's no Docker daemon inside the Dagger pre-commit container, so it could never run — `pre-commit.yaml` passed `skip-hooks: hadolint-docker`.

## Changes
- **`.pre-commit-config.yaml`** — replace the Docker-based `hadolint/hadolint` hook with a `repo: local` / `language: system` hook against the bundled `hadolint` binary (this is exactly the wiring the dagger linting module's README prescribes). Existing ignore set carried over (deduped: the old block listed `DL4006`/`DL3015` twice) and added **`SC1091`** — shellcheck can't follow the runtime-sourced `. "$HOME/.cargo/env"` in `images/ansible/Dockerfile`, which is expected.
- **`.github/workflows/pre-commit.yaml`** — pin `linting-module-version: v0.119.0` (the reusable `call-pre-commit.yaml` defaults to `v0.115.0`, which predates the bundled binary) and drop `skip-hooks: hadolint-docker`.

## Verification (real hadolint + pre-commit, locally)
- `hadolint v2.12.0` (same version the module bundles) on both repo Dockerfiles (`images/ansible/Dockerfile`, `tests/test-app/Dockerfile`) → **clean** with this ignore set.
- Installed `pre-commit` and ran `pre-commit run hadolint --all-files` with the binary on PATH → **`Lint Dockerfiles with hadolint...Passed`**.

So this should be green on CI (which now uses the v0.119.0 image that provides the binary).

> Note: depends on the reusable `call-pre-commit.yaml` accepting the `linting-module-version` input — confirmed it does (default `v0.115.0`), so the override is all that's needed; no change required in `github-workflow-templates`.

Part of #34

https://claude.ai/code/session_01XMZZG1kxJe7KtZEnsyjaDW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMZZG1kxJe7KtZEnsyjaDW)_