### PR TITLE
ci: build sthings-ansible + promote to ghcr on merge (dagger docker/trivy/crane)

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,0 +1,95 @@
+---
+name: Docker Build & Push (sthings-ansible)
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - images/ansible/**
+      - .github/workflows/docker-build.yaml
+  push:
+    branches: [main]
+    paths:
+      - images/ansible/**
+      - .github/workflows/docker-build.yaml
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  docker-build:
+    name: docker-build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set image name
+        id: image-name
+        run: echo "name=stuttgart-things/sthings-ansible" >> "$GITHUB_OUTPUT"
+
+      # Build images/ansible/Dockerfile and push to ttl.sh (ephemeral, no auth)
+      # as a build-validation step. The Dockerfile is self-contained (no COPY),
+      # so the build context is the image dir itself. Publishing the released
+      # image to ghcr.io is handled separately (see #34 follow-up).
+      - name: Dagger Build and Push (ttl.sh)
+        id: build-image
+        uses: dagger/dagger-for-github@v8.4.1
+        with:
+          version: v0.20.3
+          module: github.com/stuttgart-things/dagger/docker@v0.90.1
+          call: >-
+            build-and-push
+            --source images/ansible
+            --dockerfile Dockerfile
+            --repository-name ${{ steps.image-name.outputs.name }}
+            --registry-url ttl.sh
+            --tag "${{ github.sha }}"
+            --progress plain
+          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+
+      - name: Scan image with Trivy
+        uses: dagger/dagger-for-github@v8.4.1
+        with:
+          version: v0.20.3
+          module: github.com/stuttgart-things/dagger/trivy@v0.90.1
+          call: scan-image --image-ref="ttl.sh/${{ steps.image-name.outputs.name }}:${{ github.sha }}" --severity="HIGH,CRITICAL" --trivy-version="0.64.1" export --path=/tmp/trivy-scan-report.json
+          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+
+      - name: Upload scan report
+        uses: actions/upload-artifact@v7
+        with:
+          name: trivy-scan-report
+          path: /tmp/trivy-scan-report.json
+          retention-days: 30
+
+      - name: Check for vulnerabilities
+        run: |
+          if command -v jq &> /dev/null; then
+            VULN_COUNT=$(jq '[.Results[]?.Vulnerabilities[]?] | length' /tmp/trivy-scan-report.json 2>/dev/null || echo "0")
+            echo "Found $VULN_COUNT HIGH/CRITICAL vulnerabilities"
+            if [ "$VULN_COUNT" -gt 0 ]; then
+              echo "::warning::Image contains $VULN_COUNT HIGH/CRITICAL vulnerabilities"
+              jq -r '.Results[]? | select(.Vulnerabilities) | "\(.Target): \(.Vulnerabilities | length) vulnerabilities"' \
+                /tmp/trivy-scan-report.json
+            else
+              echo "✅ No HIGH/CRITICAL vulnerabilities found!"
+            fi
+          fi
+
+      - name: Build Summary
+        run: |
+          echo "## 🎉 sthings-ansible Image Build Complete" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Image:** \`ttl.sh/${{ steps.image-name.outputs.name }}:${{ github.sha }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Pull command:**" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`\`\`bash" >> "$GITHUB_STEP_SUMMARY"
+          echo "docker pull ttl.sh/${{ steps.image-name.outputs.name }}:${{ github.sha }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "⏰ **Note:** ttl.sh images expire after 1 hour" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -20,24 +20,23 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  IMAGE: stuttgart-things/sthings-ansible
+  REGISTRY: ghcr.io
+
 jobs:
-  docker-build:
-    name: docker-build
+  # PR / manual: build images/ansible/Dockerfile and push to ttl.sh (ephemeral,
+  # no auth) as a build-validation gate, then trivy-scan the result. No ghcr
+  # writes here, so fork PRs stay green.
+  build-validate:
+    name: build-validate (ttl.sh)
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set image name
-        id: image-name
-        run: echo "name=stuttgart-things/sthings-ansible" >> "$GITHUB_OUTPUT"
-
-      # Build images/ansible/Dockerfile and push to ttl.sh (ephemeral, no auth)
-      # as a build-validation step. The Dockerfile is self-contained (no COPY),
-      # so the build context is the image dir itself. Publishing the released
-      # image to ghcr.io is handled separately (see #34 follow-up).
       - name: Dagger Build and Push (ttl.sh)
-        id: build-image
         uses: dagger/dagger-for-github@v8.4.1
         with:
           version: v0.20.3
@@ -46,7 +45,7 @@ jobs:
             build-and-push
             --source images/ansible
             --dockerfile Dockerfile
-            --repository-name ${{ steps.image-name.outputs.name }}
+            --repository-name ${{ env.IMAGE }}
             --registry-url ttl.sh
             --tag "${{ github.sha }}"
             --progress plain
@@ -57,7 +56,7 @@ jobs:
         with:
           version: v0.20.3
           module: github.com/stuttgart-things/dagger/trivy@v0.90.1
-          call: scan-image --image-ref="ttl.sh/${{ steps.image-name.outputs.name }}:${{ github.sha }}" --severity="HIGH,CRITICAL" --trivy-version="0.64.1" export --path=/tmp/trivy-scan-report.json
+          call: scan-image --image-ref="ttl.sh/${{ env.IMAGE }}:${{ github.sha }}" --severity="HIGH,CRITICAL" --trivy-version="0.64.1" export --path=/tmp/trivy-scan-report.json
           cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
 
       - name: Upload scan report
@@ -67,29 +66,115 @@ jobs:
           path: /tmp/trivy-scan-report.json
           retention-days: 30
 
-      - name: Check for vulnerabilities
-        run: |
-          if command -v jq &> /dev/null; then
-            VULN_COUNT=$(jq '[.Results[]?.Vulnerabilities[]?] | length' /tmp/trivy-scan-report.json 2>/dev/null || echo "0")
-            echo "Found $VULN_COUNT HIGH/CRITICAL vulnerabilities"
-            if [ "$VULN_COUNT" -gt 0 ]; then
-              echo "::warning::Image contains $VULN_COUNT HIGH/CRITICAL vulnerabilities"
-              jq -r '.Results[]? | select(.Vulnerabilities) | "\(.Target): \(.Vulnerabilities | length) vulnerabilities"' \
-                /tmp/trivy-scan-report.json
-            else
-              echo "✅ No HIGH/CRITICAL vulnerabilities found!"
-            fi
-          fi
-
       - name: Build Summary
         run: |
-          echo "## 🎉 sthings-ansible Image Build Complete" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Image:** \`ttl.sh/${{ steps.image-name.outputs.name }}:${{ github.sha }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Pull command:**" >> "$GITHUB_STEP_SUMMARY"
-          echo "\`\`\`bash" >> "$GITHUB_STEP_SUMMARY"
-          echo "docker pull ttl.sh/${{ steps.image-name.outputs.name }}:${{ github.sha }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "⏰ **Note:** ttl.sh images expire after 1 hour" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## 🧪 sthings-ansible build validated (ttl.sh)"
+            echo ""
+            echo "**Image:** \`ttl.sh/${{ env.IMAGE }}:${{ github.sha }}\`"
+            echo ""
+            echo "⏰ ttl.sh images expire after 1 hour."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # Merge to main: build once → push to ghcr by immutable :sha, then use the
+  # dagger crane module to re-tag that exact digest to :<ANSIBLE_VERSION> and
+  # :latest (promotion, no rebuild).
+  publish:
+    name: publish (ghcr)
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      REGISTRY_USERNAME: ${{ github.actor }}
+      REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Resolve image version from Dockerfile
+        id: meta
+        run: |
+          version=$(grep -oP '^ARG ANSIBLE_VERSION=\K.*' images/ansible/Dockerfile)
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: ${version}"
+
+      - name: Dagger Build and Push (ghcr :sha)
+        uses: dagger/dagger-for-github@v8.4.1
+        with:
+          version: v0.20.3
+          module: github.com/stuttgart-things/dagger/docker@v0.90.1
+          call: >-
+            build-and-push
+            --source images/ansible
+            --dockerfile Dockerfile
+            --repository-name ${{ env.IMAGE }}
+            --registry-url ${{ env.REGISTRY }}
+            --registry-username env:REGISTRY_USERNAME
+            --registry-password env:REGISTRY_PASSWORD
+            --tag "${{ github.sha }}"
+            --progress plain
+          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+
+      - name: Scan image with Trivy
+        uses: dagger/dagger-for-github@v8.4.1
+        with:
+          version: v0.20.3
+          module: github.com/stuttgart-things/dagger/trivy@v0.90.1
+          call: scan-image --image-ref="${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ github.sha }}" --severity="HIGH,CRITICAL" --trivy-version="0.64.1" export --path=/tmp/trivy-scan-report.json
+          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+
+      - name: Upload scan report
+        uses: actions/upload-artifact@v7
+        with:
+          name: trivy-scan-report
+          path: /tmp/trivy-scan-report.json
+          retention-days: 30
+
+      # crane copy = re-tag by digest (no rebuild). Source is the private ghcr
+      # :sha just pushed, so source creds are passed alongside target creds.
+      - name: Crane re-tag :sha → :version
+        uses: dagger/dagger-for-github@v8.4.1
+        with:
+          version: v0.20.3
+          module: github.com/stuttgart-things/dagger/crane@v0.91.0
+          call: >-
+            copy
+            --source ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ github.sha }}
+            --target ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ steps.meta.outputs.version }}
+            --source-registry ${{ env.REGISTRY }}
+            --source-username ${{ github.actor }}
+            --source-password env:REGISTRY_PASSWORD
+            --target-registry ${{ env.REGISTRY }}
+            --target-username ${{ github.actor }}
+            --target-password env:REGISTRY_PASSWORD
+          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+
+      - name: Crane re-tag :sha → :latest
+        uses: dagger/dagger-for-github@v8.4.1
+        with:
+          version: v0.20.3
+          module: github.com/stuttgart-things/dagger/crane@v0.91.0
+          call: >-
+            copy
+            --source ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ github.sha }}
+            --target ${{ env.REGISTRY }}/${{ env.IMAGE }}:latest
+            --source-registry ${{ env.REGISTRY }}
+            --source-username ${{ github.actor }}
+            --source-password env:REGISTRY_PASSWORD
+            --target-registry ${{ env.REGISTRY }}
+            --target-username ${{ github.actor }}
+            --target-password env:REGISTRY_PASSWORD
+          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+
+      - name: Publish Summary
+        run: |
+          {
+            echo "## 🚀 sthings-ansible published to ghcr.io"
+            echo ""
+            echo "Built once as \`:${{ github.sha }}\`, crane-promoted to:"
+            echo ""
+            echo "- \`${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ steps.meta.outputs.version }}\`"
+            echo "- \`${{ env.REGISTRY }}/${{ env.IMAGE }}:latest\`"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Adds image CI for `images/ansible/Dockerfile` using the dagger [`docker`](https://github.com/stuttgart-things/dagger/tree/main/docker), [`trivy`](https://github.com/stuttgart-things/dagger/tree/main/trivy), and [`crane`](https://github.com/stuttgart-things/dagger/tree/main/crane) modules — the maintainer-deferred "sthings-ansible image build/publish CI" follow-up from #34.

Two jobs, gated by event:

### `build-validate` (PR / `workflow_dispatch`)
Build the image with the `docker` module's `build-and-push` → **ttl.sh** (ephemeral, no auth), then **trivy** scan (HIGH/CRITICAL) + report artifact. No ghcr writes, so fork PRs stay green. Modelled on [`sthings-backstage/docker-build.yaml`](https://github.com/stuttgart-things/sthings-backstage/blob/main/.github/workflows/docker-build.yaml) (minus its Node/yarn build steps — our image is a self-contained Dockerfile, no `COPY`).

### `publish` (push to `main` / merge)
**Build once, crane-promote** (chosen approach A):
1. `docker build-and-push` → `ghcr.io/stuttgart-things/sthings-ansible:<sha>` (immutable, auth via `GITHUB_TOKEN`).
2. `trivy` scan the ghcr `:sha` image.
3. `crane copy` re-tags that **exact digest** → `:<ANSIBLE_VERSION>` (read from the Dockerfile `ARG`, currently `14.0.0`) and → `:latest`. No rebuild — crane copies by digest. Source creds are passed since the `:sha` package is private on ghcr.

Pins: `dagger-for-github@v8.4.1`, dagger `v0.20.3`, `docker@v0.90.1`, `trivy@v0.90.1`, `crane@v0.91.0`. Path-scoped to `images/ansible/**` + this workflow.

## Reviewer notes
- ⚠️ **The `publish` job does not run on this PR** — it's gated to `push` on `main`. Its first real execution is the **merge of this PR**, which will publish `sthings-ansible:14.0.0` + `:latest` to ghcr. Only `build-validate` (ttl.sh) is exercised on the PR.
- First publish may need the org/package to allow `GITHUB_TOKEN` (packages: write) to create/push the package; if the package already exists, confirm Actions has write access. Easy to verify on the first merge run.

## Validation
Passes the repo's pre-commit suite on the workflow file: `check-jsonschema` **Validate GitHub Workflows**, `detect-secrets`, whitespace/EOF. The ttl.sh build path was confirmed green in CI on the previous revision of this PR (real dagger build of the ansible image + trivy scan).

Part of #34

https://claude.ai/code/session_01XMZZG1kxJe7KtZEnsyjaDW