### PR TITLE
feat(tasks): add execute-tofu task with per-run private CA trust

### DIFF
--- a/.k2n/examples/tr-execute-tofu.yaml
+++ b/.k2n/examples/tr-execute-tofu.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: execute-tofu-run
+  namespace: tekton-ci
+spec:
+  taskRef:
+    name: execute-tofu
+  params:
+    - name: ACTION
+      value: "apply"
+    - name: AUTO_APPROVE
+      value: "true"
+    - name: SUB_DIRECTORY
+      value: "terraform"
+    - name: TF_VARS
+      value:
+        - "region+-'eu-central-1'"
+        - "instance_count+-2"
+    - name: BACKEND_CONFIG
+      value:
+        - "bucket+-my-tf-state"
+        - "key+-stage-time/terraform.tfstate"
+  workspaces:
+    - name: source
+      persistentVolumeClaim:
+        claimName: terraform-source-pvc
+    # optional - private CA trust, per run (omit if not needed)
+    - name: ca-certs
+      secret:
+        secretName: private-ca

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -88,3 +88,56 @@ EOF
 ```
 
 </details>
+
+<details><summary>EXECUTE TERRAFORM</summary>
+
+Runs `terraform init` followed by a `plan`, `apply` or `destroy` against the
+configuration in the `source` workspace. Per-key variables (`TF_VARS`) and a
+base64 tfvars file (`TF_VARS_FILE`) are written as `*.auto.tfvars`. Provider
+credentials are injected from an optional secret (`credentials-secret-name`)
+whose keys become environment variables (e.g. `AWS_ACCESS_KEY_ID`,
+`ARM_CLIENT_ID`, `GOOGLE_CREDENTIALS`, `TF_VAR_*`).
+
+Optionally create a credentials secret:
+
+```bash
+kubectl create secret generic terraform-credentials \
+--from-literal=AWS_ACCESS_KEY_ID=<KEY> \
+--from-literal=AWS_SECRET_ACCESS_KEY=<SECRET> \
+-n tekton-ci
+```
+
+```bash
+kubectl apply -f - <<EOF
+---
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: execute-terraform-test
+  namespace: tekton-ci
+spec:
+  taskRef:
+    name: execute-terraform
+  params:
+    - name: ACTION
+      value: "apply"
+    - name: AUTO_APPROVE
+      value: "true"
+    - name: SUB_DIRECTORY
+      value: "terraform"
+    - name: TF_VARS
+      value:
+        - "region+-'eu-central-1'"
+        - "instance_count+-2"
+    - name: BACKEND_CONFIG
+      value:
+        - "bucket+-my-tf-state"
+        - "key+-stage-time/terraform.tfstate"
+  workspaces:
+    - name: source
+      persistentVolumeClaim:
+        claimName: terraform-source-pvc
+EOF
+```
+
+</details>

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -89,21 +89,29 @@ EOF
 
 </details>
 
-<details><summary>EXECUTE TERRAFORM</summary>
+<details><summary>EXECUTE OPENTOFU</summary>
 
-Runs `terraform init` followed by a `plan`, `apply` or `destroy` against the
+Runs `tofu init` followed by a `plan`, `apply` or `destroy` against the
 configuration in the `source` workspace. Per-key variables (`TF_VARS`) and a
 base64 tfvars file (`TF_VARS_FILE`) are written as `*.auto.tfvars`. Provider
 credentials are injected from an optional secret (`credentials-secret-name`)
 whose keys become environment variables (e.g. `AWS_ACCESS_KEY_ID`,
 `ARM_CLIENT_ID`, `GOOGLE_CREDENTIALS`, `TF_VAR_*`).
 
-Optionally create a credentials secret:
+Private CA certificates can be trusted per run (not baked into the image) by
+binding the optional `ca-certs` workspace; any `*.crt` / `*.pem` files there
+are appended to the system trust store via `SSL_CERT_FILE`.
+
+Optionally create a credentials secret and a CA cert secret:
 
 ```bash
 kubectl create secret generic terraform-credentials \
 --from-literal=AWS_ACCESS_KEY_ID=<KEY> \
 --from-literal=AWS_SECRET_ACCESS_KEY=<SECRET> \
+-n tekton-ci
+
+kubectl create secret generic private-ca \
+--from-file=ca.crt=./my-private-ca.crt \
 -n tekton-ci
 ```
 
@@ -113,11 +121,11 @@ kubectl apply -f - <<EOF
 apiVersion: tekton.dev/v1
 kind: TaskRun
 metadata:
-  name: execute-terraform-test
+  name: execute-tofu-test
   namespace: tekton-ci
 spec:
   taskRef:
-    name: execute-terraform
+    name: execute-tofu
   params:
     - name: ACTION
       value: "apply"
@@ -137,6 +145,9 @@ spec:
     - name: source
       persistentVolumeClaim:
         claimName: terraform-source-pvc
+    - name: ca-certs       # optional - private CA trust, per run
+      secret:
+        secretName: private-ca
 EOF
 ```
 

--- a/tasks/execute-terraform.yaml
+++ b/tasks/execute-terraform.yaml
@@ -1,0 +1,290 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: execute-terraform
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/categories: "infrastructure"
+    tekton.dev/pipelines.minVersion: "0.17.0"
+    tekton.dev/platforms: "linux/amd64,linux/arm64"
+    tekton.dev/tags: "terraform,iac"
+spec:
+  description: execute terraform (init/plan/apply/destroy) with enhanced security and error handling
+  workspaces:
+    - name: source
+      description: holds the working data (terraform configuration)
+      optional: false
+  params:
+    - name: ACTION
+      description: terraform action to perform (plan, apply or destroy)
+      type: string
+      default: "plan"
+    - name: SUB_DIRECTORY
+      description: subdirectory of workspace containing the terraform configuration
+      type: string
+      default: ""
+    - name: AUTO_APPROVE
+      description: skip interactive approval for apply/destroy
+      type: string
+      default: "true"
+    - name: TF_VARS
+      description: extra terraform variables, array of key+-value (later written to tekton.auto.tfvars)
+      type: array
+      default: []
+    - name: TF_VARS_FILE
+      description: tfvars file as b64 (merged via *.auto.tfvars, takes precedence over TF_VARS)
+      type: string
+      default: ""
+    - name: BACKEND_CONFIG
+      description: terraform backend config, array of key+-value passed as -backend-config
+      type: array
+      default: []
+    - name: INIT_EXTRA_ARGS
+      description: extra arguments passed to terraform init. WARNING - must be sanitized to avoid command injection
+      type: string
+      default: ""
+    - name: PLAN_EXTRA_ARGS
+      description: extra arguments passed to terraform plan/apply/destroy. WARNING - must be sanitized to avoid command injection
+      type: string
+      default: ""
+    - name: TF_LOG
+      description: terraform log level (TRACE, DEBUG, INFO, WARN, ERROR or empty to disable)
+      type: string
+      default: ""
+    - name: USER_HOME
+      description: absolute path to the user's home directory
+      type: string
+      default: "/home/nonroot"
+    - name: WORKING_IMAGE
+      description: the image on which terraform will run
+      type: string
+      default: "docker.io/hashicorp/terraform:1.9"
+    - name: credentials-secret-name
+      description: >-
+        name of an optional secret whose keys are injected as environment
+        variables (e.g. AWS_ACCESS_KEY_ID, ARM_CLIENT_ID, GOOGLE_CREDENTIALS,
+        TF_VAR_*)
+      type: string
+      default: "terraform-credentials"
+    - name: vault-secret-key-addr
+      description: vault addr key in the secret
+      type: string
+      default: "VAULT_ADDR"
+    - name: vault-secret-key-approleId
+      description: approle id key in the secret
+      type: string
+      default: "VAULT_ROLE_ID"
+    - name: vault-secret-key-approleSecret
+      description: approle secret key in the secret
+      type: string
+      default: "VAULT_SECRET_ID"
+    - name: vault-secret-key-namespace
+      description: namespace key in the secret
+      type: string
+      default: "VAULT_NAMESPACE"
+    - name: vault-secret-name
+      description: name of the vault secret
+      type: string
+      default: "vault"
+  results:
+    - name: action-performed
+      description: the terraform action that was executed
+  stepTemplate:
+    workingDir: $(workspaces.source.path)/$(params.SUB_DIRECTORY)
+    image: "$(params.WORKING_IMAGE)"
+    env:
+      - name: HOME
+        value: $(params.USER_HOME)
+      - name: TF_IN_AUTOMATION
+        value: "true"
+      - name: TF_LOG
+        value: $(params.TF_LOG)
+    securityContext:
+      privileged: false
+      runAsNonRoot: true
+      runAsUser: 65532
+    # Requests only (no limits): give the scheduler sizing info without
+    # capping the variable footprint of terraform runs / provider downloads,
+    # which a too-low memory limit could OOM-kill.
+    computeResources:
+      requests:
+        cpu: 250m
+        memory: 256Mi
+  steps:
+    - name: create-tfvars
+      args:
+        - $(params.TF_VARS[*])
+      script: |
+        #!/usr/bin/env sh
+        set -eu
+
+        echo "Creating tekton.auto.tfvars"
+        rm -f ./tekton.auto.tfvars
+        : > ./tekton.auto.tfvars
+
+        for argument in "$@"; do
+          # Split on the FIRST '+-' only, so a value that itself contains
+          # '+-' is not mangled. Value typing is left to HCL (callers quote
+          # where a string is required, e.g. region+-'eu-central-1').
+          echo "$argument" | sed -e "s/+-/ = /" >> ./tekton.auto.tfvars
+        done
+
+        echo "Current tekton.auto.tfvars contents:"
+        cat ./tekton.auto.tfvars
+
+    - name: merge-tfvars-file
+      env:
+        - name: TF_VARS_FILE
+          value: $(params.TF_VARS_FILE)
+      script: |
+        #!/usr/bin/env sh
+        set -eu
+
+        if [ -z "${TF_VARS_FILE}" ]; then
+          echo "tfvars file is empty - nothing to merge"
+        else
+          # Written as *.auto.tfvars so terraform auto-loads it. It is loaded
+          # alphabetically after tekton.auto.tfvars, so its values take
+          # precedence over the per-key TF_VARS above.
+          echo "Decoding tfvars file from base64 -> zz-override.auto.tfvars"
+          echo "${TF_VARS_FILE}" | base64 -d > ./zz-override.auto.tfvars
+          echo "Contents:"
+          cat ./zz-override.auto.tfvars
+        fi
+
+    - name: terraform-init
+      args:
+        - $(params.BACKEND_CONFIG[*])
+      env:
+        - name: INIT_EXTRA_ARGS
+          value: $(params.INIT_EXTRA_ARGS)
+        - name: VAULT_ADDR
+          valueFrom:
+            secretKeyRef:
+              key: $(params.vault-secret-key-addr)
+              name: $(params.vault-secret-name)
+              optional: true
+        - name: VAULT_NAMESPACE
+          valueFrom:
+            secretKeyRef:
+              key: $(params.vault-secret-key-namespace)
+              name: $(params.vault-secret-name)
+              optional: true
+        - name: VAULT_ROLE_ID
+          valueFrom:
+            secretKeyRef:
+              key: $(params.vault-secret-key-approleId)
+              name: $(params.vault-secret-name)
+              optional: true
+        - name: VAULT_SECRET_ID
+          valueFrom:
+            secretKeyRef:
+              key: $(params.vault-secret-key-approleSecret)
+              name: $(params.vault-secret-name)
+              optional: true
+      envFrom:
+        - secretRef:
+            name: $(params.credentials-secret-name)
+            optional: true
+      script: |
+        #!/usr/bin/env sh
+        set -eu
+
+        # Positional params ($@) are the BACKEND_CONFIG key+-value pairs.
+        # Translate each into a -backend-config=key=value flag, appended to
+        # the positional list, then shift off the original raw pairs. Using
+        # positional params keeps each flag a single word, so values with
+        # spaces/quotes can't be re-split or globbed.
+        orig_count=$#
+        for param in "$@"; do
+          bc=$(echo "$param" | sed -e "s/+-/=/")
+          set -- "$@" "-backend-config=${bc}"
+        done
+        i=0
+        while [ "$i" -lt "$orig_count" ]; do
+          shift
+          i=$((i + 1))
+        done
+
+        echo "=========================================="
+        echo "TERRAFORM INIT"
+        echo "=========================================="
+        # INIT_EXTRA_ARGS is intentionally word-split; "$@" holds the
+        # -backend-config flags.
+        # shellcheck disable=SC2086
+        terraform init -input=false ${INIT_EXTRA_ARGS} "$@"
+
+    - name: terraform-action
+      env:
+        - name: ACTION
+          value: $(params.ACTION)
+        - name: AUTO_APPROVE
+          value: $(params.AUTO_APPROVE)
+        - name: PLAN_EXTRA_ARGS
+          value: $(params.PLAN_EXTRA_ARGS)
+        - name: VAULT_ADDR
+          valueFrom:
+            secretKeyRef:
+              key: $(params.vault-secret-key-addr)
+              name: $(params.vault-secret-name)
+              optional: true
+        - name: VAULT_NAMESPACE
+          valueFrom:
+            secretKeyRef:
+              key: $(params.vault-secret-key-namespace)
+              name: $(params.vault-secret-name)
+              optional: true
+        - name: VAULT_ROLE_ID
+          valueFrom:
+            secretKeyRef:
+              key: $(params.vault-secret-key-approleId)
+              name: $(params.vault-secret-name)
+              optional: true
+        - name: VAULT_SECRET_ID
+          valueFrom:
+            secretKeyRef:
+              key: $(params.vault-secret-key-approleSecret)
+              name: $(params.vault-secret-name)
+              optional: true
+      envFrom:
+        - secretRef:
+            name: $(params.credentials-secret-name)
+            optional: true
+      script: |
+        #!/usr/bin/env sh
+        set -eu
+
+        APPROVE_FLAG=""
+        if [ "${AUTO_APPROVE}" = "true" ]; then
+          APPROVE_FLAG="-auto-approve"
+        fi
+
+        echo "=========================================="
+        echo "TERRAFORM ${ACTION}"
+        echo "=========================================="
+
+        case "${ACTION}" in
+          plan)
+            # shellcheck disable=SC2086
+            terraform plan -input=false ${PLAN_EXTRA_ARGS} -out=tfplan
+            ;;
+          apply)
+            # shellcheck disable=SC2086
+            terraform apply -input=false ${APPROVE_FLAG} ${PLAN_EXTRA_ARGS}
+            ;;
+          destroy)
+            # shellcheck disable=SC2086
+            terraform destroy -input=false ${APPROVE_FLAG} ${PLAN_EXTRA_ARGS}
+            ;;
+          *)
+            echo "ERROR: unsupported ACTION '${ACTION}' (expected plan, apply or destroy)" >&2
+            exit 1
+            ;;
+        esac
+
+        printf '%s' "${ACTION}" > "$(results.action-performed.path)"
+        echo "=========================================="
+        echo "terraform ${ACTION} completed successfully"
+        echo "=========================================="

--- a/tasks/execute-tofu.yaml
+++ b/tasks/execute-tofu.yaml
@@ -2,27 +2,33 @@
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
-  name: execute-terraform
+  name: execute-tofu
   labels:
     app.kubernetes.io/version: "0.1"
   annotations:
     tekton.dev/categories: "infrastructure"
     tekton.dev/pipelines.minVersion: "0.17.0"
     tekton.dev/platforms: "linux/amd64,linux/arm64"
-    tekton.dev/tags: "terraform,iac"
+    tekton.dev/tags: "opentofu,terraform,iac"
 spec:
-  description: execute terraform (init/plan/apply/destroy) with enhanced security and error handling
+  description: execute opentofu (init/plan/apply/destroy) with enhanced security and error handling
   workspaces:
     - name: source
-      description: holds the working data (terraform configuration)
+      description: holds the working data (opentofu/terraform configuration)
       optional: false
+    - name: ca-certs
+      description: >-
+        optional workspace with private CA certificates (*.crt / *.pem) that
+        are trusted per run. They are appended to the system trust store at
+        runtime (via SSL_CERT_FILE) and never baked into the image.
+      optional: true
   params:
     - name: ACTION
-      description: terraform action to perform (plan, apply or destroy)
+      description: opentofu action to perform (plan, apply or destroy)
       type: string
       default: "plan"
     - name: SUB_DIRECTORY
-      description: subdirectory of workspace containing the terraform configuration
+      description: subdirectory of workspace containing the opentofu configuration
       type: string
       default: ""
     - name: AUTO_APPROVE
@@ -30,7 +36,7 @@ spec:
       type: string
       default: "true"
     - name: TF_VARS
-      description: extra terraform variables, array of key+-value (later written to tekton.auto.tfvars)
+      description: extra variables, array of key+-value (later written to tekton.auto.tfvars)
       type: array
       default: []
     - name: TF_VARS_FILE
@@ -38,19 +44,19 @@ spec:
       type: string
       default: ""
     - name: BACKEND_CONFIG
-      description: terraform backend config, array of key+-value passed as -backend-config
+      description: backend config, array of key+-value passed as -backend-config
       type: array
       default: []
     - name: INIT_EXTRA_ARGS
-      description: extra arguments passed to terraform init. WARNING - must be sanitized to avoid command injection
+      description: extra arguments passed to tofu init. WARNING - must be sanitized to avoid command injection
       type: string
       default: ""
     - name: PLAN_EXTRA_ARGS
-      description: extra arguments passed to terraform plan/apply/destroy. WARNING - must be sanitized to avoid command injection
+      description: extra arguments passed to tofu plan/apply/destroy. WARNING - must be sanitized to avoid command injection
       type: string
       default: ""
     - name: TF_LOG
-      description: terraform log level (TRACE, DEBUG, INFO, WARN, ERROR or empty to disable)
+      description: log level (TRACE, DEBUG, INFO, WARN, ERROR or empty to disable)
       type: string
       default: ""
     - name: USER_HOME
@@ -58,9 +64,9 @@ spec:
       type: string
       default: "/home/nonroot"
     - name: WORKING_IMAGE
-      description: the image on which terraform will run
+      description: the image on which opentofu will run
       type: string
-      default: "docker.io/hashicorp/terraform:1.9"
+      default: "ghcr.io/opentofu/opentofu:1.9.0"
     - name: credentials-secret-name
       description: >-
         name of an optional secret whose keys are injected as environment
@@ -90,7 +96,7 @@ spec:
       default: "vault"
   results:
     - name: action-performed
-      description: the terraform action that was executed
+      description: the opentofu action that was executed
   stepTemplate:
     workingDir: $(workspaces.source.path)/$(params.SUB_DIRECTORY)
     image: "$(params.WORKING_IMAGE)"
@@ -101,18 +107,64 @@ spec:
         value: "true"
       - name: TF_LOG
         value: $(params.TF_LOG)
+      # Per-run CA trust: the trust-ca-certs step writes a combined bundle
+      # (system roots + any private CAs from the ca-certs workspace) here.
+      # Go (opentofu/providers) and git honor these, so nothing is baked in.
+      - name: SSL_CERT_FILE
+        value: $(workspaces.source.path)/$(params.SUB_DIRECTORY)/.tekton-ca-bundle.crt
+      - name: GIT_SSL_CAINFO
+        value: $(workspaces.source.path)/$(params.SUB_DIRECTORY)/.tekton-ca-bundle.crt
     securityContext:
       privileged: false
       runAsNonRoot: true
       runAsUser: 65532
     # Requests only (no limits): give the scheduler sizing info without
-    # capping the variable footprint of terraform runs / provider downloads,
+    # capping the variable footprint of opentofu runs / provider downloads,
     # which a too-low memory limit could OOM-kill.
     computeResources:
       requests:
         cpu: 250m
         memory: 256Mi
   steps:
+    - name: trust-ca-certs
+      env:
+        - name: CA_CERTS_BOUND
+          value: $(workspaces.ca-certs.bound)
+        - name: CA_CERTS_PATH
+          value: $(workspaces.ca-certs.path)
+      script: |
+        #!/usr/bin/env sh
+        set -eu
+
+        # Build a combined CA bundle: system roots first, then any private
+        # CAs mounted via the ca-certs workspace. SSL_CERT_FILE (set in the
+        # stepTemplate) points every later step at this file. When no
+        # ca-certs workspace is bound the bundle equals the system store, so
+        # behaviour is unchanged.
+        BUNDLE="${SSL_CERT_FILE}"
+        : > "${BUNDLE}"
+
+        if [ -f /etc/ssl/certs/ca-certificates.crt ]; then
+          cat /etc/ssl/certs/ca-certificates.crt >> "${BUNDLE}"
+        fi
+
+        if [ "${CA_CERTS_BOUND}" = "true" ]; then
+          echo "Appending private CA certificates from ca-certs workspace"
+          found=0
+          for crt in "${CA_CERTS_PATH}"/*.crt "${CA_CERTS_PATH}"/*.pem; do
+            [ -f "${crt}" ] || continue
+            echo "  + ${crt}"
+            printf '\n' >> "${BUNDLE}"
+            cat "${crt}" >> "${BUNDLE}"
+            found=1
+          done
+          [ "${found}" = "0" ] && echo "  (no *.crt / *.pem files found)"
+        else
+          echo "No ca-certs workspace bound - using system trust store only"
+        fi
+
+        echo "CA bundle written to ${BUNDLE}"
+
     - name: create-tfvars
       args:
         - $(params.TF_VARS[*])
@@ -145,7 +197,7 @@ spec:
         if [ -z "${TF_VARS_FILE}" ]; then
           echo "tfvars file is empty - nothing to merge"
         else
-          # Written as *.auto.tfvars so terraform auto-loads it. It is loaded
+          # Written as *.auto.tfvars so opentofu auto-loads it. It is loaded
           # alphabetically after tekton.auto.tfvars, so its values take
           # precedence over the per-key TF_VARS above.
           echo "Decoding tfvars file from base64 -> zz-override.auto.tfvars"
@@ -154,7 +206,7 @@ spec:
           cat ./zz-override.auto.tfvars
         fi
 
-    - name: terraform-init
+    - name: tofu-init
       args:
         - $(params.BACKEND_CONFIG[*])
       env:
@@ -209,14 +261,14 @@ spec:
         done
 
         echo "=========================================="
-        echo "TERRAFORM INIT"
+        echo "TOFU INIT"
         echo "=========================================="
         # INIT_EXTRA_ARGS is intentionally word-split; "$@" holds the
         # -backend-config flags.
         # shellcheck disable=SC2086
-        terraform init -input=false ${INIT_EXTRA_ARGS} "$@"
+        tofu init -input=false ${INIT_EXTRA_ARGS} "$@"
 
-    - name: terraform-action
+    - name: tofu-action
       env:
         - name: ACTION
           value: $(params.ACTION)
@@ -262,21 +314,21 @@ spec:
         fi
 
         echo "=========================================="
-        echo "TERRAFORM ${ACTION}"
+        echo "TOFU ${ACTION}"
         echo "=========================================="
 
         case "${ACTION}" in
           plan)
             # shellcheck disable=SC2086
-            terraform plan -input=false ${PLAN_EXTRA_ARGS} -out=tfplan
+            tofu plan -input=false ${PLAN_EXTRA_ARGS} -out=tfplan
             ;;
           apply)
             # shellcheck disable=SC2086
-            terraform apply -input=false ${APPROVE_FLAG} ${PLAN_EXTRA_ARGS}
+            tofu apply -input=false ${APPROVE_FLAG} ${PLAN_EXTRA_ARGS}
             ;;
           destroy)
             # shellcheck disable=SC2086
-            terraform destroy -input=false ${APPROVE_FLAG} ${PLAN_EXTRA_ARGS}
+            tofu destroy -input=false ${APPROVE_FLAG} ${PLAN_EXTRA_ARGS}
             ;;
           *)
             echo "ERROR: unsupported ACTION '${ACTION}' (expected plan, apply or destroy)" >&2
@@ -286,5 +338,5 @@ spec:
 
         printf '%s' "${ACTION}" > "$(results.action-performed.path)"
         echo "=========================================="
-        echo "terraform ${ACTION} completed successfully"
+        echo "tofu ${ACTION} completed successfully"
         echo "=========================================="


### PR DESCRIPTION
## Summary

Adds an `execute-tofu` Tekton Task that runs OpenTofu (`init` → `plan`/`apply`/`destroy`) against a configuration in the `source` workspace, modeled on the existing `execute-ansible` task conventions.

## Details

- **OpenTofu**: defaults to `ghcr.io/opentofu/opentofu:1.9.0`, uses the `tofu` binary (license-clean, CLI-compatible).
- **Actions**: `ACTION` = `plan` / `apply` / `destroy`, with `AUTO_APPROVE` and `PLAN_EXTRA_ARGS` / `INIT_EXTRA_ARGS`.
- **Variables**: per-key `TF_VARS` (array, `key+-value`) → `tekton.auto.tfvars`; base64 `TF_VARS_FILE` → `zz-override.auto.tfvars` (auto-loaded last, so it wins).
- **Backend**: `BACKEND_CONFIG` array → `-backend-config` flags.
- **Credentials**: vault `VAULT_*` secretKeyRefs (optional) plus `credentials-secret-name` injected via `envFrom` (all keys → env: `AWS_*`, `ARM_*`, `GOOGLE_CREDENTIALS`, `TF_VAR_*`).
- **Private CA trust (per run, not baked in)**: optional `ca-certs` workspace; a `trust-ca-certs` step concatenates the system roots with any `*.crt`/`*.pem` into a bundle, exposed via `SSL_CERT_FILE` / `GIT_SSL_CAINFO`. Works as non-root (uid 65532) with no `update-ca-certificates` or image rebuild.
- Follows existing conventions: `stepTemplate`, non-root securityContext, requests-only resources, `set --` argv building.
- Adds an `EXECUTE OPENTOFU` section to `tasks/README.md` and a `.k2n/examples/tr-execute-tofu.yaml` TaskRun example.

## Notes

- Pinned `ghcr.io/opentofu/opentofu:1.9.0` as the default image — Renovate should track it like the other image pins.

https://claude.ai/code/session_01VBFMEbtVJCSG4LkHa3faGJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VBFMEbtVJCSG4LkHa3faGJ)_