### PR TITLE
feat(packer): wrap Packer in Tekton (image, task, pipeline, KCL modules)

### DIFF
--- a/.github/workflows/docker-build-packer.yaml
+++ b/.github/workflows/docker-build-packer.yaml
@@ -1,0 +1,180 @@
+---
+name: Docker Build & Push (sthings-packer)
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - images/packer/**
+      - .github/workflows/docker-build-packer.yaml
+  push:
+    branches: [main]
+    paths:
+      - images/packer/**
+      - .github/workflows/docker-build-packer.yaml
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  IMAGE: stuttgart-things/sthings-packer
+  REGISTRY: ghcr.io
+
+jobs:
+  # PR / manual: build images/packer/Dockerfile and push to ttl.sh (ephemeral,
+  # no auth) as a build-validation gate, then trivy-scan the result. No ghcr
+  # writes here, so fork PRs stay green.
+  build-validate:
+    name: build-validate (ttl.sh)
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Dagger Build and Push (ttl.sh)
+        uses: dagger/dagger-for-github@v8.4.1
+        with:
+          version: v0.20.3
+          module: github.com/stuttgart-things/dagger/docker@v0.90.1
+          call: >-
+            build-and-push
+            --source images/packer
+            --dockerfile Dockerfile
+            --repository-name ${{ env.IMAGE }}
+            --registry-url ttl.sh
+            --tag "${{ github.sha }}"
+            --progress plain
+          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+
+      - name: Scan image with Trivy
+        uses: dagger/dagger-for-github@v8.4.1
+        with:
+          version: v0.20.3
+          module: github.com/stuttgart-things/dagger/trivy@v0.90.1
+          call: scan-image --image-ref="ttl.sh/${{ env.IMAGE }}:${{ github.sha }}" --severity="HIGH,CRITICAL" --trivy-version="0.64.1" export --path=/tmp/trivy-scan-report.json
+          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+
+      - name: Upload scan report
+        uses: actions/upload-artifact@v7
+        with:
+          name: trivy-scan-report
+          path: /tmp/trivy-scan-report.json
+          retention-days: 30
+
+      - name: Build Summary
+        run: |
+          {
+            echo "## 🧪 sthings-packer build validated (ttl.sh)"
+            echo ""
+            echo "**Image:** \`ttl.sh/${{ env.IMAGE }}:${{ github.sha }}\`"
+            echo ""
+            echo "⏰ ttl.sh images expire after 1 hour."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # Merge to main: build once → push to ghcr by immutable :sha, then use the
+  # dagger crane module to re-tag that exact digest to :<PACKER_VERSION> and
+  # :latest (promotion, no rebuild).
+  publish:
+    name: publish (ghcr)
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      REGISTRY_USERNAME: ${{ github.actor }}
+      REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Resolve image version from Dockerfile
+        id: meta
+        run: |
+          version=$(grep -oP '^ARG PACKER_VERSION=\K.*' images/packer/Dockerfile)
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: ${version}"
+
+      - name: Dagger Build and Push (ghcr :sha)
+        uses: dagger/dagger-for-github@v8.4.1
+        with:
+          version: v0.20.3
+          module: github.com/stuttgart-things/dagger/docker@v0.90.1
+          call: >-
+            build-and-push
+            --source images/packer
+            --dockerfile Dockerfile
+            --repository-name ${{ env.IMAGE }}
+            --registry-url ${{ env.REGISTRY }}
+            --registry-username env:REGISTRY_USERNAME
+            --registry-password env:REGISTRY_PASSWORD
+            --tag "${{ github.sha }}"
+            --progress plain
+          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+
+      - name: Scan image with Trivy
+        uses: dagger/dagger-for-github@v8.4.1
+        with:
+          version: v0.20.3
+          module: github.com/stuttgart-things/dagger/trivy@v0.90.1
+          call: scan-image --image-ref="${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ github.sha }}" --severity="HIGH,CRITICAL" --trivy-version="0.64.1" export --path=/tmp/trivy-scan-report.json
+          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+
+      - name: Upload scan report
+        uses: actions/upload-artifact@v7
+        with:
+          name: trivy-scan-report
+          path: /tmp/trivy-scan-report.json
+          retention-days: 30
+
+      # crane copy = re-tag by digest (no rebuild). Source is the private ghcr
+      # :sha just pushed, so source creds are passed alongside target creds.
+      - name: Crane re-tag :sha → :version
+        uses: dagger/dagger-for-github@v8.4.1
+        with:
+          version: v0.20.3
+          module: github.com/stuttgart-things/dagger/crane@v0.91.0
+          call: >-
+            copy
+            --source ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ github.sha }}
+            --target ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ steps.meta.outputs.version }}
+            --source-registry ${{ env.REGISTRY }}
+            --source-username ${{ github.actor }}
+            --source-password env:REGISTRY_PASSWORD
+            --target-registry ${{ env.REGISTRY }}
+            --target-username ${{ github.actor }}
+            --target-password env:REGISTRY_PASSWORD
+          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+
+      - name: Crane re-tag :sha → :latest
+        uses: dagger/dagger-for-github@v8.4.1
+        with:
+          version: v0.20.3
+          module: github.com/stuttgart-things/dagger/crane@v0.91.0
+          call: >-
+            copy
+            --source ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ github.sha }}
+            --target ${{ env.REGISTRY }}/${{ env.IMAGE }}:latest
+            --source-registry ${{ env.REGISTRY }}
+            --source-username ${{ github.actor }}
+            --source-password env:REGISTRY_PASSWORD
+            --target-registry ${{ env.REGISTRY }}
+            --target-username ${{ github.actor }}
+            --target-password env:REGISTRY_PASSWORD
+          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+
+      - name: Publish Summary
+        run: |
+          {
+            echo "## 🚀 sthings-packer published to ghcr.io"
+            echo ""
+            echo "Built once as \`:${{ github.sha }}\`, crane-promoted to:"
+            echo ""
+            echo "- \`${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ steps.meta.outputs.version }}\`"
+            echo "- \`${{ env.REGISTRY }}/${{ env.IMAGE }}:latest\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/kcl-validate.yaml
+++ b/.github/workflows/kcl-validate.yaml
@@ -22,6 +22,8 @@ jobs:
           - kcl/ansible
           - kcl/ansible-run
           - kcl/buildah
+          - kcl/packer
+          - kcl/packer-run
     # NOTE: requires call-kcl-validate.yaml to be merged into
     # github-workflow-templates' main branch first.
     uses: stuttgart-things/github-workflow-templates/.github/workflows/call-kcl-validate.yaml@main

--- a/.k2n/examples/tr-execute-tofu.yaml
+++ b/.k2n/examples/tr-execute-tofu.yaml
@@ -29,4 +29,4 @@ spec:
     # optional - private CA trust, per run (omit if not needed)
     - name: ca-certs
       secret:
-        secretName: private-ca
+        secretName: private-ca # pragma: allowlist secret

--- a/images/packer/Dockerfile
+++ b/images/packer/Dockerfile
@@ -2,11 +2,11 @@
 FROM ghcr.io/stuttgart-things/sthings-alpine:3.11.14-alpine3.23
 
 # METADATA INFORMATION
-LABEL version=1.12.0
+LABEL version=1.15.1
 LABEL maintainer="Patrick Hermann <patrick.hermann@sva.de>"
 
 # SOFTWARE
-ARG PACKER_VERSION=1.12.0
+ARG PACKER_VERSION=1.15.1
 ARG YQ_VERSION=4.53.2
 # Plugin versions baked into the image. They must satisfy the
 # `required_plugins` constraints in the templates this image builds; if a

--- a/images/packer/Dockerfile
+++ b/images/packer/Dockerfile
@@ -1,0 +1,50 @@
+# BASE
+FROM ghcr.io/stuttgart-things/sthings-alpine:3.11.14-alpine3.23
+
+# METADATA INFORMATION
+LABEL version=1.12.0
+LABEL maintainer="Patrick Hermann <patrick.hermann@sva.de>"
+
+# SOFTWARE
+ARG PACKER_VERSION=1.12.0
+ARG YQ_VERSION=4.53.2
+# Plugin versions baked into the image. They must satisfy the
+# `required_plugins` constraints in the templates this image builds; if a
+# template pins a newer plugin, `packer init` pulls it at run time (needs
+# network). Bump these alongside the templates to keep runs offline-fast.
+ARG PACKER_PLUGIN_VSPHERE_VERSION=1.4.2
+ARG PACKER_PLUGIN_PROXMOX_VERSION=1.2.2
+ARG PACKER_PLUGIN_QEMU_VERSION=1.1.0
+
+# NON-ROOT USER ID AND GROUP ID
+ENV USER_ID=65532 \
+    GROUP_ID=65532
+
+# RUNTIME PACKAGES (kept in the final image) + packer + yq.
+# openssh-client/git: templates that provision over SSH or fetch sources.
+# unzip: packer releases ship as a zip. ca-certificates: TLS to builders.
+RUN apk add --no-cache git curl wget tar bash unzip ca-certificates openssh-client \
+    && curl -fsSL "https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip" -o /tmp/packer.zip \
+    && unzip /tmp/packer.zip -d /usr/bin \
+    && chmod +x /usr/bin/packer \
+    && rm -f /tmp/packer.zip \
+    && curl -fsSL "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64" -o /usr/bin/yq \
+    && chmod +x /usr/bin/yq
+
+# PACKER PLUGINS — baked into the nonroot user's plugin dir so `packer init`
+# resolves them offline and runs don't re-download on every PipelineRun.
+# PACKER_PLUGIN_PATH is exported so the runtime user (65532) finds them
+# regardless of HOME.
+ENV PACKER_PLUGIN_PATH=/home/nonroot/.config/packer/plugins
+RUN mkdir -p ${PACKER_PLUGIN_PATH} \
+    && chown -R ${USER_ID}:${GROUP_ID} /home/nonroot/.config
+USER 65532
+WORKDIR /home/nonroot
+RUN packer plugins install github.com/hashicorp/vsphere "${PACKER_PLUGIN_VSPHERE_VERSION}" \
+    && packer plugins install github.com/hashicorp/proxmox "${PACKER_PLUGIN_PROXMOX_VERSION}" \
+    && packer plugins install github.com/hashicorp/qemu "${PACKER_PLUGIN_QEMU_VERSION}"
+
+USER root
+
+# DEFAULT ENTRYPOINT AND/OR COMMAND (IF REQUIRED, CAN BE ADDED HERE)
+CMD ["bash"]

--- a/kcl/packer-run/README.md
+++ b/kcl/packer-run/README.md
@@ -1,0 +1,37 @@
+# PACKER-RUN
+
+> **What this is:** a **client-side generator for the `PackerBuild` XR**
+> (`resources.stuttgart-things.com/v1alpha1`) — it renders the *request* object
+> you `kubectl apply`. It is **not** the Composition renderer; that is
+> [`kcl/packer`](../packer) (`kcl-tekton-pr-packer`), which turns a
+> `PackerBuild` spec into a Tekton `PipelineRun`.
+>
+> The **canonical schema** is the XRD in
+> [`stuttgart-things/crossplane-configurations`](https://github.com/stuttgart-things/crossplane-configurations)
+> (`cicd/packer-build/apis/definition.yaml`). The fields this generator exposes
+> are a **subset** of it — for the full spec and authoritative examples, see
+> that XRD and `cicd/packer-build/examples/xr*.yaml`.
+
+## RENDER XR (build a golden image)
+
+```bash
+kcl run main.k \
+  -D name=ubuntu24-labul-base-os \
+  -D metadataNamespace=default \
+  -D wrapInCrossplane=true \
+  -D crossplaneProviderConfig=dev \
+  -D namespace=tekton-ci \
+  -D osVersion=ubuntu24 \
+  -D lab=labul \
+  -D provisioning=base-os \
+  -D credentialsSecretName=packer-credentials | kubectl apply -f -
+```
+
+## RENDER XR (explicit subdirectory, restrict to one source)
+
+```bash
+kcl run main.k \
+  -D name=rocky9-labda \
+  -D gitWorkspaceSubdirectory=packer/builds/rocky9-labda-vsphere-base-os \
+  -D packerOnly=vsphere-iso.rocky9
+```

--- a/kcl/packer-run/kcl.mod
+++ b/kcl/packer-run/kcl.mod
@@ -1,0 +1,4 @@
+[package]
+name = "packer-run"
+edition = "v0.11.2"
+version = "0.0.1"

--- a/kcl/packer-run/main.k
+++ b/kcl/packer-run/main.k
@@ -1,0 +1,90 @@
+"""
+PackerBuild Main Configuration
+Supports both Composition format and flat format with -D overrides
+"""
+
+# kcl/packer-run — CLIENT-SIDE GENERATOR for the PackerBuild XR
+# (resources.stuttgart-things.com/v1alpha1).
+#
+# This renders the *request* object you `kubectl apply`. It is NOT the
+# Composition renderer — that is kcl/packer (kcl-tekton-pr-packer), which turns
+# a PackerBuild spec into a Tekton PipelineRun.
+#
+# The canonical schema is the XRD in stuttgart-things/crossplane-configurations
+# (cicd/packer-build/apis/definition.yaml). The fields below are a SUBSET; for
+# the full spec and authoritative examples see that XRD and
+# cicd/packer-build/examples/xr*.yaml.
+import .schema
+
+# --- Read parameters (supports both Composition format and flat format) ---
+_params = option("params") or {}
+_spec = _params?.oxr?.spec or {}
+
+# If no nested structure, use flat parameters directly
+_flat_params = _spec if _spec else _params
+
+# --- Extract fields from spec (with fallbacks to direct options) ---
+
+# Metadata
+_name = _flat_params?.name or option("name") or "packer-build"
+_metadataNamespace = _flat_params?.metadataNamespace or option("metadataNamespace") or "default"
+
+# Crossplane Configuration
+_wrapInCrossplane = _flat_params?.wrapInCrossplane or option("wrapInCrossplane") or True
+_crossplaneObjectName = _flat_params?.crossplaneObjectName or option("crossplaneObjectName") or _name
+_crossplaneNamespace = _flat_params?.crossplaneNamespace or option("crossplaneNamespace") or "default"
+_crossplaneProviderConfig = _flat_params?.crossplaneProviderConfig or option("crossplaneProviderConfig") or "default"
+
+# PipelineRun Configuration
+_pipelineRunName = _flat_params?.pipelineRunName or option("pipelineRunName") or _name
+_namespace = _flat_params?.namespace or option("namespace") or "tekton-ci"
+
+# Template source / build selectors
+_gitRepoUrl = _flat_params?.gitRepoUrl or option("gitRepoUrl") or "https://github.com/stuttgart-things/stuttgart-things.git"
+_gitRevision = _flat_params?.gitRevision or option("gitRevision") or "main"
+_gitWorkspaceSubdirectory = _flat_params?.gitWorkspaceSubdirectory or option("gitWorkspaceSubdirectory") or ""
+_osVersion = _flat_params?.osVersion or option("osVersion") or ""
+_lab = _flat_params?.lab or option("lab") or ""
+_provisioning = _flat_params?.provisioning or option("provisioning") or ""
+
+# Packer Configuration
+_packerAction = _flat_params?.packerAction or option("packerAction") or "build"
+_packerTemplate = _flat_params?.packerTemplate or option("packerTemplate") or "."
+_packerOnly = _flat_params?.packerOnly or option("packerOnly") or ""
+_packerForce = _flat_params?.packerForce or option("packerForce") or "false"
+_packerVars = _flat_params?.packerVars or option("packerVars") or []
+_packerVarsFile = _flat_params?.packerVarsFile or option("packerVarsFile") or ""
+_credentialsSecretName = _flat_params?.credentialsSecretName or option("credentialsSecretName") or "packer-credentials"
+_vaultSecretName = _flat_params?.vaultSecretName or option("vaultSecretName") or "vault"
+
+# --- Generate PackerBuild Resource ---
+_packerBuild = schema.PackerBuild {
+    metadata = schema.Metadata {
+        name = _name
+        namespace = _metadataNamespace
+    }
+    spec = schema.PackerBuildSpec {
+        wrapInCrossplane = _wrapInCrossplane
+        crossplaneObjectName = _crossplaneObjectName
+        crossplaneNamespace = _crossplaneNamespace
+        crossplaneProviderConfig = _crossplaneProviderConfig
+        pipelineRunName = _pipelineRunName
+        namespace = _namespace
+        gitRepoUrl = _gitRepoUrl
+        gitRevision = _gitRevision
+        gitWorkspaceSubdirectory = _gitWorkspaceSubdirectory
+        osVersion = _osVersion
+        lab = _lab
+        provisioning = _provisioning
+        packerAction = _packerAction
+        packerTemplate = _packerTemplate
+        packerOnly = _packerOnly
+        packerForce = _packerForce
+        packerVars = _packerVars
+        packerVarsFile = _packerVarsFile
+        credentialsSecretName = _credentialsSecretName
+        vaultSecretName = _vaultSecretName
+    }
+}
+
+_packerBuild

--- a/kcl/packer-run/schema.k
+++ b/kcl/packer-run/schema.k
@@ -47,3 +47,4 @@ schema PackerBuild:
     kind: str = "PackerBuild"
     metadata: Metadata
     spec: PackerBuildSpec
+

--- a/kcl/packer-run/schema.k
+++ b/kcl/packer-run/schema.k
@@ -1,0 +1,49 @@
+"""
+PackerBuild Schema Definition
+"""
+
+schema Metadata:
+    """
+    Kubernetes metadata
+    """
+    name: str
+    namespace?: str
+
+schema PackerBuildSpec:
+    """
+    Specification for PackerBuild custom resource
+    """
+    # Crossplane Configuration
+    wrapInCrossplane?: bool
+    crossplaneObjectName?: str
+    crossplaneNamespace?: str
+    crossplaneProviderConfig?: str
+    # PipelineRun Configuration
+    pipelineRunName?: str
+    namespace?: str
+    # Template source (where the *.pkr.hcl live)
+    gitRepoUrl?: str
+    gitRevision?: str
+    gitWorkspaceSubdirectory?: str
+    # High-level build selectors (compose gitWorkspaceSubdirectory)
+    osVersion?: str
+    lab?: str
+    provisioning?: str
+    # Packer Configuration
+    packerAction?: str
+    packerTemplate?: str
+    packerOnly?: str
+    packerForce?: str
+    packerVars?: [str]
+    packerVarsFile?: str
+    credentialsSecretName?: str
+    vaultSecretName?: str
+
+schema PackerBuild:
+    """
+    PackerBuild custom resource definition
+    """
+    apiVersion: str = "resources.stuttgart-things.com/v1alpha1"
+    kind: str = "PackerBuild"
+    metadata: Metadata
+    spec: PackerBuildSpec

--- a/kcl/packer/CLAUDE.md
+++ b/kcl/packer/CLAUDE.md
@@ -1,0 +1,54 @@
+# CLAUDE.md — KCL module `kcl-tekton-pr-packer`
+
+Context for working on this KCL module with Claude Code.
+
+## What & where
+- This directory is the KCL module **`kcl-tekton-pr-packer`** (`kcl.mod`:
+  package `kcl-tekton-pr-packer`, edition `v0.11.2`, entry `main.k`, dependency
+  `tekton-pipelines = "1.0.0"`).
+- Purpose: render a Tekton **PipelineRun** for the `build-packer-template`
+  pipeline from a `PackerBuild`-shaped input, optionally wrapped in a
+  `kubernetes.m.crossplane.io/v1alpha1` **Object** (provider-kubernetes).
+- The Packer sibling of [`kcl/ansible`](../ansible) (`kcl-tekton-pr`). The
+  client-side XR generator is [`kcl/packer-run`](../packer-run).
+- Published manually to `oci://ghcr.io/stuttgart-things/kcl-tekton-pr-packer`
+  (OCI tag = `version` in `kcl.mod`). No CI publishes it — `kcl mod push`.
+- Files: `main.k` (field resolution + validation + render), `defaults.k`
+  (static run settings), `vars.k` (re-exports + name prefix).
+
+## Two-repo split (the key difference vs the ansible module)
+`kcl-tekton-pr` conflates pipeline-definition and source repo into one
+`gitRepoUrl`. This module keeps them separate because packer templates live in
+a DIFFERENT repo than the pipeline:
+- `pipelineRepoUrl`/`pipelineRevision`/`pipelinePath` → the PipelineRun's
+  `pipelineRef` git resolver (this repo, `pipelines/build-packer-template.yaml`).
+- `gitRepoUrl`/`gitRevision`/`gitWorkspaceSubdirectory` → pipeline PARAMS that
+  tell the git-clone task which `*.pkr.hcl` to check out
+  (`stuttgart-things/stuttgart-things`, `packer/builds/<os>-<lab>-vsphere-<prov>/`).
+- `osVersion`+`lab`+`provisioning` compose `gitWorkspaceSubdirectory` when it
+  isn't set explicitly (mirrors the `dispatch-packer-build` action's BUILD_DIR).
+
+## Invocation contract (two modes)
+Same as `kcl-tekton-pr`: Composition mode (`params.oxr.spec` + `ctx` env +
+`ocds` + `dxr`, output `items=[...]`) or flat `-D` mode (single resource).
+Precedence: `oxr.spec.<field>` → EnvironmentConfig → `-D` option → default.
+
+## Opt-in readiness
+`deriveReadiness` (default `false`): only takes effect with
+`wrapInCrossplane=true` — it adds `spec.readiness.policy: DeriveFromCelQuery`
+to the Object so it is Ready only once the PipelineRun's `Succeeded` condition
+is True. Bare PipelineRun → silent no-op.
+
+## Local render / test
+```bash
+kcl run main.k -D osVersion=ubuntu24 -D lab=labul -D provisioning=base-os -D wrapInCrossplane=true
+```
+Always render before bumping the version — `kcl` is the source of truth for
+whether the module is valid.
+
+## Consumer
+`stuttgart-things/crossplane-configurations` → `cicd/packer-build` (planned):
+the Composition's `render-pipelinerun` step pins a specific tag of this module.
+The pinned version MUST be published or the Configuration's verify CI fails
+with `failed to resolve <v>: ...kcl-tekton-pr-packer:<v>: not found`. Order:
+bump `kcl.mod` → `kcl mod push` → bump the pin in the consumer.

--- a/kcl/packer/README.md
+++ b/kcl/packer/README.md
@@ -1,0 +1,68 @@
+# kcl-tekton-pr-packer
+
+> Renders a Tekton **PipelineRun** for the `build-packer-template` pipeline
+> from a `PackerBuild`-shaped input, optionally wrapped in a
+> `kubernetes.m.crossplane.io/v1alpha1` **Object** (provider-kubernetes) so
+> Crossplane applies it on a target cluster.
+>
+> This is the Packer sibling of [`kcl/ansible`](../ansible)
+> (`kcl-tekton-pr`). The **client-side XR generator** is
+> [`kcl/packer-run`](../packer-run); this module is the **renderer** the
+> Crossplane Composition consumes.
+
+Published manually to `oci://ghcr.io/stuttgart-things/kcl-tekton-pr-packer`
+(the OCI tag = `version` in `kcl.mod`):
+
+```bash
+kcl mod push oci://ghcr.io/stuttgart-things/kcl-tekton-pr-packer
+```
+
+## Two repos, on purpose
+
+Unlike the ansible module, this one keeps the **pipeline definition** and the
+**template source** as separate refs:
+
+- `pipelineRepoUrl` / `pipelineRevision` / `pipelinePath` — where
+  `build-packer-template.yaml` lives (this repo, `stage-time`).
+- `gitRepoUrl` / `gitRevision` / `gitWorkspaceSubdirectory` — where the
+  `*.pkr.hcl` templates live (`stuttgart-things/stuttgart-things`, under
+  `packer/builds/<os>-<lab>-vsphere-<provisioning>/`).
+
+`osVersion` + `lab` + `provisioning` compose `gitWorkspaceSubdirectory`
+automatically (mirroring the `dispatch-packer-build` action's `BUILD_DIR`)
+when it isn't set explicitly.
+
+## Invocation contract (two modes)
+
+`main.k` reads `option("params")` and supports both:
+
+- **Composition mode** (`function-kcl`): `params.oxr.spec`,
+  `params.ctx["apiextensions.crossplane.io/environment"]`, `params.ocds`,
+  `params.dxr`. Output: `items = [...]`.
+- **Flat / `-D` mode** (local runs): `-D key=value` overrides. Output: a
+  single resource.
+
+Per-field precedence: `oxr.spec.<field>` → EnvironmentConfig (`_env`) → `-D`
+option → hardcoded default.
+
+## Local render
+
+```bash
+# Flat mode (build ubuntu24 in labul, base-os provisioning):
+kcl run main.k \
+  -D osVersion=ubuntu24 \
+  -D lab=labul \
+  -D provisioning=base-os \
+  -D wrapInCrossplane=true
+
+# Explicit subdirectory + restrict to one source:
+kcl run main.k \
+  -D gitWorkspaceSubdirectory=packer/builds/ubuntu24-labul-vsphere-base-os \
+  -D packerOnly=vsphere-iso.ubuntu24
+```
+
+## Readiness
+
+`deriveReadiness` (default `false`): when true AND `wrapInCrossplane=true`, the
+wrapped Object reports `Ready` only once the PipelineRun's `Succeeded`
+condition is `True`. With a bare PipelineRun it is a silent no-op.

--- a/kcl/packer/defaults.k
+++ b/kcl/packer/defaults.k
@@ -1,0 +1,11 @@
+# Static, non-field pipeline-run settings.
+# Per-field default values live in main.k (single source of truth).
+_task_run_template = {
+    serviceAccountName = "default"
+}
+
+# Packer builds (golden images) take a while; give the pipeline a generous
+# ceiling. Override via spec/-D if a builder is slower.
+_timeouts = {
+    pipeline = "2h0m0s"
+}

--- a/kcl/packer/kcl.mod
+++ b/kcl/packer/kcl.mod
@@ -1,0 +1,12 @@
+[package]
+name = "kcl-tekton-pr-packer"
+edition = "v0.11.2"
+version = "0.1.0"
+
+[dependencies]
+tekton-pipelines = "1.0.0"
+
+[profile]
+entries = [
+    "main.k"
+]

--- a/kcl/packer/kcl.mod.lock
+++ b/kcl/packer/kcl.mod.lock
@@ -1,0 +1,17 @@
+[dependencies]
+  [dependencies.k8s]
+    name = "k8s"
+    full_name = "k8s_1.32.4"
+    version = "1.32.4"
+    sum = "WrltC/mTXtdzmhBZxlvM71wJL5C/UZ/vW+bF3nFvNbM="
+    reg = "ghcr.io"
+    repo = "kcl-lang/k8s"
+    oci_tag = "1.32.4"
+  [dependencies.tekton-pipelines]
+    name = "tekton-pipelines"
+    full_name = "tekton-pipelines_1.0.0"
+    version = "1.0.0"
+    sum = "0nPHi/qA9Gqd+P06YrrD/35IDbv3hAVP59SgtXnDb2U="
+    reg = "ghcr.io"
+    repo = "kcl-lang/tekton-pipelines"
+    oci_tag = "1.0.0"

--- a/kcl/packer/main.k
+++ b/kcl/packer/main.k
@@ -1,0 +1,194 @@
+# main.k
+import tekton_pipelines.v1 as tekton
+import .vars
+import datetime
+import crypto
+
+# --- Read parameters (supports both Composition format and flat format) ---
+_params = option("params") or {}
+_spec = _params?.oxr?.spec or {}
+
+# If no nested structure, use flat parameters directly
+_flat_params = _spec if _spec else _params
+
+# --- Crossplane EnvironmentConfig context ---
+# `function-environment-configs` merges the `data` of the selected
+# EnvironmentConfig(s) into the pipeline context under this well-known key.
+# Precedence: explicit XR spec value -> EnvironmentConfig -> flat -D option ->
+# hardcoded default. When no EnvironmentConfig is selected (or in flat/-D
+# mode) `_env` is empty and behaviour is unchanged.
+_env = _params?.ctx?["apiextensions.crossplane.io/environment"] or {}
+
+# --- Storage (PipelineRun workspace PVC) ---
+_storageSize = _flat_params?.storageSize or option("storageSize") or "5Gi"
+_storageAccessModes = _flat_params?.storageAccessModes or option("storageAccessModes") or "ReadWriteOnce"
+_storageClass = _flat_params?.storageClass or _env?.storageClass or option("storageClass") or "openebs-hostpath"
+
+# --- PipelineRun placement ---
+_namespace = _flat_params?.namespace or _env?.namespace or option("namespace") or "tekton-ci"
+_pipelineRunName = _flat_params?.pipelineRunName or option("pipelineRunName") or None
+
+# --- Pipeline DEFINITION location (where build-packer-template.yaml lives).
+# This is the stage-time repo and is DISTINCT from the template source repo
+# below — packer templates live elsewhere (stuttgart-things/stuttgart-things).
+_pipelineRepoUrl = _flat_params?.pipelineRepoUrl or _env?.pipelineRepoUrl or option("pipelineRepoUrl") or "https://github.com/stuttgart-things/stage-time.git"
+_pipelineRevision = _flat_params?.pipelineRevision or _env?.pipelineRevision or option("pipelineRevision") or "main"
+_pipelinePath = _flat_params?.pipelinePath or _env?.pipelinePath or option("pipelinePath") or "pipelines/build-packer-template.yaml"
+
+# --- Template SOURCE repo (the .pkr.hcl templates the pipeline checks out) ---
+_gitRepoUrl = _flat_params?.gitRepoUrl or _env?.gitRepoUrl or option("gitRepoUrl") or "https://github.com/stuttgart-things/stuttgart-things.git"
+_gitRevision = _flat_params?.gitRevision or option("gitRevision") or "main"
+
+# Higher-level build selectors, mirroring the dispatch-packer-build action's
+# BUILD_DIR = packer/builds/<os>-<lab>-vsphere-<provisioning>. When
+# gitWorkspaceSubdirectory is not given explicitly but os/lab/provisioning are,
+# the subdirectory is composed from them.
+_osVersion = _flat_params?.osVersion or option("osVersion") or ""
+_lab = _flat_params?.lab or _env?.lab or option("lab") or ""
+_provisioning = _flat_params?.provisioning or option("provisioning") or ""
+_computedSubdir = "packer/builds/${_osVersion}-${_lab}-vsphere-${_provisioning}" if (_osVersion and _lab and _provisioning) else ""
+_gitWorkspaceSubdirectory = _flat_params?.gitWorkspaceSubdirectory or option("gitWorkspaceSubdirectory") or _computedSubdir or ""
+
+# --- Packer run configuration ---
+_packerAction = _flat_params?.packerAction or option("packerAction") or "build"
+_packerTemplate = _flat_params?.packerTemplate or option("packerTemplate") or "."
+_packerOnly = _flat_params?.packerOnly or option("packerOnly") or ""
+_packerForce = _flat_params?.packerForce or option("packerForce") or "false"
+_packerRunInit = _flat_params?.packerRunInit or option("packerRunInit") or "true"
+_packerVars = _flat_params?.packerVars or option("packerVars") or []
+_packerVarsFile = _flat_params?.packerVarsFile or option("packerVarsFile") or ""
+_packerInitExtraArgs = _flat_params?.packerInitExtraArgs or option("packerInitExtraArgs") or ""
+_packerBuildExtraArgs = _flat_params?.packerBuildExtraArgs or option("packerBuildExtraArgs") or ""
+_packerLog = _flat_params?.packerLog or option("packerLog") or ""
+_packerWorkingImage = _flat_params?.packerWorkingImage or _env?.packerWorkingImage or option("packerWorkingImage") or "ghcr.io/stuttgart-things/sthings-packer:1.15.1"
+_credentialsSecretName = _flat_params?.credentialsSecretName or _env?.credentialsSecretName or option("credentialsSecretName") or "packer-credentials"
+_vaultSecretName = _flat_params?.vaultSecretName or option("vaultSecretName") or "vault"
+_userHome = _flat_params?.userHome or option("userHome") or "/home/nonroot"
+
+# Input validation (asserts on resolved values, so it covers both composition
+# oxr.spec inputs and flat -D options).
+assert _packerWorkingImage.startswith("ghcr.io/") or _packerWorkingImage.startswith("docker.io/") or _packerWorkingImage.startswith("quay.io/"), "packerWorkingImage must be from ghcr.io, docker.io, or quay.io"
+assert _gitRepoUrl.startswith("https://github.com/"), "gitRepoUrl must be a valid GitHub HTTPS URL"
+assert _pipelineRepoUrl.startswith("https://github.com/"), "pipelineRepoUrl must be a valid GitHub HTTPS URL"
+assert len(_gitRevision) > 0, "gitRevision cannot be empty"
+assert _packerAction in ["init", "validate", "build"], "packerAction must be init, validate or build"
+assert _storageSize.endswith("Mi") or _storageSize.endswith("Gi"), "storageSize must end with 'Mi' or 'Gi'"
+assert _storageAccessModes in ["ReadWriteOnce", "ReadWriteMany", "ReadOnlyMany"], "storageAccessModes must be ReadWriteOnce, ReadWriteMany, or ReadOnlyMany"
+
+# --- Crossplane wrapper settings ---
+_wrapInCrossplane = _flat_params?.wrapInCrossplane or option("wrapInCrossplane") or False
+_crossplaneObjectName = _flat_params?.crossplaneObjectName or option("crossplaneObjectName") or "packer-build-run"
+_crossplaneNamespace = _flat_params?.crossplaneNamespace or option("crossplaneNamespace") or "default"
+_crossplaneProviderConfig = _flat_params?.crossplaneProviderConfig or option("crossplaneProviderConfig") or "kubernetes-provider"
+_crossplaneTimeout = _flat_params?.crossplaneTimeout or option("crossplaneTimeout") or "120"
+
+# Opt-in: when true the wrapped Object only reports Ready once the
+# PipelineRun's "Succeeded" condition is True (via provider-kubernetes
+# DeriveFromCelQuery). Off by default so other consumers keep "ready on create".
+_deriveReadiness = _flat_params?.deriveReadiness or option("deriveReadiness") or False
+
+# --- Generate timestamp and suffix (for the default PipelineRun name) ---
+_timestamp = str(datetime.now())
+_suffix = crypto.md5(_timestamp)[:8:]
+
+# --- pipelineRef git resolver (pipeline DEFINITION location) ---
+_pipeline_ref_override = {
+    url = _pipelineRepoUrl
+    revision = _pipelineRevision
+    pathInRepo = _pipelinePath
+}
+
+_workspace_config_override = {
+    name = "shared-workspace"
+    volumeClaimTemplate = {
+        spec = {
+            accessModes = [_storageAccessModes]
+            resources = {
+                requests = {
+                    storage = _storageSize
+                }
+            }
+            storageClassName = _storageClass
+        }
+    }
+}
+
+# Pipeline params — keys must match build-packer-template.yaml's param names.
+_pipeline_params_override = {
+    packerAction = _packerAction
+    packerTemplate = _packerTemplate
+    packerOnly = _packerOnly
+    packerForce = _packerForce
+    packerRunInit = _packerRunInit
+    packerVars = _packerVars
+    packerVarsFile = _packerVarsFile
+    packerInitExtraArgs = _packerInitExtraArgs
+    packerBuildExtraArgs = _packerBuildExtraArgs
+    packerLog = _packerLog
+    packerWorkingImage = _packerWorkingImage
+    credentialsSecretName = _credentialsSecretName
+    vaultSecretName = _vaultSecretName
+    userHome = _userHome
+    gitRepoUrl = _gitRepoUrl
+    gitRevision = _gitRevision
+    gitWorkspaceSubdirectory = _gitWorkspaceSubdirectory
+}
+
+# --- Generate the PipelineRun ---
+_pipelineRun = tekton.PipelineRun {
+    metadata = {
+        name = _pipelineRunName or "${vars._pipeline_name_prefix}-${_suffix}"
+        namespace = _namespace
+    }
+    spec = {
+        pipelineRef = {
+            resolver = "git"
+            params = [{name = k, value = v} for k, v in _pipeline_ref_override]
+        }
+        params = [{name = k, value = v} for k, v in _pipeline_params_override]
+        taskRunTemplate = vars._task_run_template
+        timeouts = vars._timeouts
+        workspaces = [_workspace_config_override]
+    }
+}
+
+# --- Crossplane Object wrapper ---
+_crossplaneObject = {
+    apiVersion = "kubernetes.m.crossplane.io/v1alpha1"
+    kind = "Object"
+    metadata = {
+        name = _crossplaneObjectName
+        namespace = _crossplaneNamespace
+        annotations = {
+            "uptest.upbound.io/timeout" = _crossplaneTimeout
+        }
+    }
+    spec = {
+        forProvider = {
+            manifest = _pipelineRun
+        }
+        providerConfigRef = {
+            kind = "ClusterProviderConfig"
+            name = _crossplaneProviderConfig
+        }
+        if _deriveReadiness:
+            readiness = {
+                policy = "DeriveFromCelQuery"
+                celQuery = "has(object.status) && has(object.status.conditions) && object.status.conditions.exists(c, c.type == \"Succeeded\" && c.status == \"True\")"
+            }
+    }
+}
+
+# --- Output based on mode ---
+# Nested Composition format -> items array. Otherwise single resource.
+if _spec:
+    items = [
+        if _wrapInCrossplane:
+            _crossplaneObject
+        else:
+            _pipelineRun
+    ]
+elif _wrapInCrossplane:
+    _crossplaneObject
+else:
+    _pipelineRun

--- a/kcl/packer/vars.k
+++ b/kcl/packer/vars.k
@@ -1,0 +1,8 @@
+# vars.k
+import .defaults
+
+# Re-export from defaults so main.k can access them
+_task_run_template = defaults._task_run_template
+_timeouts = defaults._timeouts
+
+_pipeline_name_prefix = option("pipelinePrefix") or "build-packer-template"

--- a/pipelines/build-packer-template.yaml
+++ b/pipelines/build-packer-template.yaml
@@ -79,6 +79,10 @@ spec:
       type: string
       default: ""
       description: subdirectory on workspace
+  results:
+    - name: template-name
+      description: name of the template/artifact produced by the build
+      value: $(tasks.execute-packer.results.template-name)
   tasks:
     - name: fetch-repository
       taskRef:

--- a/pipelines/build-packer-template.yaml
+++ b/pipelines/build-packer-template.yaml
@@ -1,0 +1,157 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: build-packer-template
+spec:
+  workspaces:
+    - name: shared-workspace
+    - name: sshCredentials
+      optional: true
+    - name: caCerts
+      optional: true
+  params:
+    - name: packerAction
+      type: string
+      default: "build"
+      description: packer action to perform (init, validate or build)
+    - name: packerTemplate
+      type: string
+      default: "."
+      description: packer template file or directory to act on (relative to working dir)
+    - name: packerOnly
+      type: string
+      default: ""
+      description: comma-separated build sources to restrict the build to (packer -only)
+    - name: packerForce
+      type: string
+      default: "false"
+      description: force a build, overwriting any existing artifacts (packer -force)
+    - name: packerRunInit
+      type: string
+      default: "true"
+      description: run "packer init" before validate/build to install required plugins
+    - name: packerVars
+      type: array
+      default: []
+      description: extra variables, array of key+-value (written to tekton.auto.pkrvars.hcl)
+    - name: packerVarsFile
+      type: string
+      default: ""
+      description: pkrvars file as b64 (merged via *.auto.pkrvars.hcl, takes precedence over packerVars)
+    - name: packerInitExtraArgs
+      type: string
+      default: ""
+      description: extra arguments passed to packer init
+    - name: packerBuildExtraArgs
+      type: string
+      default: ""
+      description: extra arguments passed to packer validate/build
+    - name: packerLog
+      type: string
+      default: ""
+      description: enable packer debug logging (1 to enable, empty to disable)
+    - name: packerWorkingImage
+      type: string
+      default: "ghcr.io/stuttgart-things/sthings-packer:1.12.0"
+      description: the image on which packer will run
+    - name: credentialsSecretName
+      type: string
+      default: "packer-credentials"
+      description: name of the secret whose keys are injected as env vars (builder credentials)
+    - name: vaultSecretName
+      type: string
+      default: "vault"
+      description: name of the vault secret
+    - name: userHome
+      type: string
+      default: "/home/nonroot"
+      description: absolute path to the user's home directory
+    - name: gitRepoUrl
+      type: string
+      default: ""
+      description: source git repo (holds the packer templates)
+    - name: gitRevision
+      type: string
+      default: "main"
+      description: revision of source git repo
+    - name: gitWorkspaceSubdirectory
+      type: string
+      default: ""
+      description: subdirectory on workspace
+  tasks:
+    - name: fetch-repository
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/tektoncd/catalog.git
+          # Pinned to a fixed commit for reproducibility/supply-chain safety
+          # (external dependency). tektoncd/catalog main @ 2026-06; bump
+          # deliberately.
+          - name: revision
+            value: 7ea2968e224633b4967d60217b33bb4d38fa53d9 # pragma: allowlist secret (git commit SHA, not a secret)
+          - name: pathInRepo
+            value: task/git-clone/0.10/git-clone.yaml
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+        - name: ssh-directory
+          workspace: sshCredentials
+      params:
+        - name: deleteExisting
+          value: 'true'
+        - name: revision
+          value: $(params.gitRevision)
+        - name: subdirectory
+          value: $(params.gitWorkspaceSubdirectory)
+        - name: url
+          value: $(params.gitRepoUrl)
+    - name: execute-packer
+      runAfter:
+        - fetch-repository
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/stuttgart-things/stage-time.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/execute-packer.yaml
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+        - name: ca-certs
+          workspace: caCerts
+      params:
+        - name: ACTION
+          value: $(params.packerAction)
+        - name: TEMPLATE
+          value: $(params.packerTemplate)
+        - name: ONLY
+          value: $(params.packerOnly)
+        - name: FORCE
+          value: $(params.packerForce)
+        - name: RUN_INIT
+          value: $(params.packerRunInit)
+        - name: PKR_VARS
+          value: $(params.packerVars[*])
+        - name: PKR_VARS_FILE
+          value: $(params.packerVarsFile)
+        - name: INIT_EXTRA_ARGS
+          value: $(params.packerInitExtraArgs)
+        - name: BUILD_EXTRA_ARGS
+          value: $(params.packerBuildExtraArgs)
+        - name: PACKER_LOG
+          value: $(params.packerLog)
+        - name: WORKING_IMAGE
+          value: $(params.packerWorkingImage)
+        - name: SUB_DIRECTORY
+          value: $(params.gitWorkspaceSubdirectory)
+        - name: USER_HOME
+          value: $(params.userHome)
+        - name: credentials-secret-name
+          value: $(params.credentialsSecretName)
+        - name: vault-secret-name
+          value: $(params.vaultSecretName)

--- a/pipelines/build-packer-template.yaml
+++ b/pipelines/build-packer-template.yaml
@@ -53,7 +53,7 @@ spec:
       description: enable packer debug logging (1 to enable, empty to disable)
     - name: packerWorkingImage
       type: string
-      default: "ghcr.io/stuttgart-things/sthings-packer:1.12.0"
+      default: "ghcr.io/stuttgart-things/sthings-packer:1.15.1"
       description: the image on which packer will run
     - name: credentialsSecretName
       type: string

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -170,8 +170,11 @@ per run (not baked into the image) by binding the optional `ca-certs` workspace;
 any `*.crt` / `*.pem` files there are appended to the system trust store via
 `SSL_CERT_FILE`.
 
-When the template uses the manifest post-processor (`packer-manifest.json`), the
-last build's `artifact_id` is surfaced as the `artifact-id` result.
+The name of the built template is parsed from packer's artifact log line and
+surfaced as the `template-name` result; a build that produces no artifact fails
+the task (downstream promote/rename steps depend on that name). Vault is wired
+the same way as the ansible/tofu tasks — `VAULT_ADDR`/`VAULT_ROLE_ID`/
+`VAULT_SECRET_ID`/`VAULT_TOKEN` are read from the `vault` secret.
 
 ```bash
 kubectl create secret generic packer-credentials \

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -152,3 +152,63 @@ EOF
 ```
 
 </details>
+
+<details><summary>EXECUTE PACKER</summary>
+
+Runs `packer init` followed by `validate` or `build` against the HCL
+template(s) in the `source` workspace, to build VM templates / golden images
+(vSphere / Proxmox / qemu). Per-key variables (`PKR_VARS`) and a base64 pkrvars
+file (`PKR_VARS_FILE`) are written as `*.auto.pkrvars.hcl`. Builder credentials
+are injected from an optional secret (`credentials-secret-name`, default
+`packer-credentials`) whose keys become environment variables (e.g.
+`PKR_VAR_vsphere_password`, `PROXMOX_TOKEN`, ...).
+
+The common plugins (`vsphere`, `proxmox`, `qemu`) are baked into the
+`sthings-packer` image so `packer init` resolves them offline; a template that
+pins a newer plugin pulls it at run time. Private CA certificates can be trusted
+per run (not baked into the image) by binding the optional `ca-certs` workspace;
+any `*.crt` / `*.pem` files there are appended to the system trust store via
+`SSL_CERT_FILE`.
+
+When the template uses the manifest post-processor (`packer-manifest.json`), the
+last build's `artifact_id` is surfaced as the `artifact-id` result.
+
+```bash
+kubectl create secret generic packer-credentials \
+--from-literal=PKR_VAR_vsphere_password=<PASSWORD> \
+-n tekton-ci
+```
+
+```bash
+kubectl apply -f - <<EOF
+---
+apiVersion: tekton.dev/v1
+kind: TaskRun
+metadata:
+  name: execute-packer-test
+  namespace: tekton-ci
+spec:
+  taskRef:
+    name: execute-packer
+  params:
+    - name: ACTION
+      value: "build"
+    - name: SUB_DIRECTORY
+      value: "packer"
+    - name: TEMPLATE
+      value: "ubuntu24.pkr.hcl"
+    - name: PKR_VARS
+      value:
+        - "vm_name+-'ubuntu24-golden'"
+        - "vsphere_datacenter+-'dc-01'"
+  workspaces:
+    - name: source
+      persistentVolumeClaim:
+        claimName: packer-source-pvc
+    - name: ca-certs       # optional - private CA trust, per run
+      secret:
+        secretName: private-ca
+EOF
+```
+
+</details>

--- a/tasks/execute-packer.yaml
+++ b/tasks/execute-packer.yaml
@@ -1,0 +1,364 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: execute-packer
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/categories: "infrastructure"
+    tekton.dev/pipelines.minVersion: "0.17.0"
+    tekton.dev/platforms: "linux/amd64,linux/arm64"
+    tekton.dev/tags: "packer,image-build,iac"
+spec:
+  description: build vm templates / golden images with packer (init/validate/build) with enhanced security and error handling
+  workspaces:
+    - name: source
+      description: holds the working data (packer HCL templates)
+      optional: false
+    - name: ca-certs
+      description: >-
+        optional workspace with private CA certificates (*.crt / *.pem) that
+        are trusted per run. They are appended to the system trust store at
+        runtime (via SSL_CERT_FILE) and never baked into the image.
+      optional: true
+  params:
+    - name: ACTION
+      description: packer action to perform (init, validate or build)
+      type: string
+      default: "build"
+    - name: SUB_DIRECTORY
+      description: subdirectory of workspace containing the packer template(s)
+      type: string
+      default: ""
+    - name: TEMPLATE
+      description: packer template file or directory to act on (relative to working dir)
+      type: string
+      default: "."
+    - name: ONLY
+      description: comma-separated build sources to restrict the build to (packer -only). Empty = all
+      type: string
+      default: ""
+    - name: FORCE
+      description: force a build, overwriting any existing artifacts (packer -force)
+      type: string
+      default: "false"
+    - name: RUN_INIT
+      description: run "packer init" before validate/build to install required plugins
+      type: string
+      default: "true"
+    - name: PKR_VARS
+      description: extra variables, array of key+-value (later written to tekton.auto.pkrvars.hcl)
+      type: array
+      default: []
+    - name: PKR_VARS_FILE
+      description: pkrvars file as b64 (merged via *.auto.pkrvars.hcl, takes precedence over PKR_VARS)
+      type: string
+      default: ""
+    - name: INIT_EXTRA_ARGS
+      description: extra arguments passed to packer init. WARNING - must be sanitized to avoid command injection
+      type: string
+      default: ""
+    - name: BUILD_EXTRA_ARGS
+      description: extra arguments passed to packer validate/build. WARNING - must be sanitized to avoid command injection
+      type: string
+      default: ""
+    - name: PACKER_LOG
+      description: enable packer debug logging (1 to enable, empty to disable)
+      type: string
+      default: ""
+    - name: USER_HOME
+      description: absolute path to the user's home directory
+      type: string
+      default: "/home/nonroot"
+    - name: WORKING_IMAGE
+      description: the image on which packer will run
+      type: string
+      default: "ghcr.io/stuttgart-things/sthings-packer:1.12.0"
+    - name: credentials-secret-name
+      description: >-
+        name of an optional secret whose keys are injected as environment
+        variables (e.g. vSphere/Proxmox/Harvester builder credentials such as
+        PKR_VAR_vsphere_password, PROXMOX_TOKEN, ...)
+      type: string
+      default: "packer-credentials"
+    - name: vault-secret-key-addr
+      description: vault addr key in the secret
+      type: string
+      default: "VAULT_ADDR"
+    - name: vault-secret-key-approleId
+      description: approle id key in the secret
+      type: string
+      default: "VAULT_ROLE_ID"
+    - name: vault-secret-key-approleSecret
+      description: approle secret key in the secret
+      type: string
+      default: "VAULT_SECRET_ID"
+    - name: vault-secret-key-namespace
+      description: namespace key in the secret
+      type: string
+      default: "VAULT_NAMESPACE"
+    - name: vault-secret-name
+      description: name of the vault secret
+      type: string
+      default: "vault"
+  results:
+    - name: action-performed
+      description: the packer action that was executed
+    - name: artifact-id
+      description: >-
+        best-effort artifact id of the last build, read from a
+        packer-manifest.json (manifest post-processor) if present; empty otherwise
+  stepTemplate:
+    workingDir: $(workspaces.source.path)/$(params.SUB_DIRECTORY)
+    image: "$(params.WORKING_IMAGE)"
+    env:
+      - name: HOME
+        value: $(params.USER_HOME)
+      - name: PACKER_LOG
+        value: $(params.PACKER_LOG)
+      # Per-run CA trust: the trust-ca-certs step writes a combined bundle
+      # (system roots + any private CAs from the ca-certs workspace) here.
+      # Go (packer/plugins) and git honor these, so nothing is baked in.
+      - name: SSL_CERT_FILE
+        value: $(workspaces.source.path)/$(params.SUB_DIRECTORY)/.tekton-ca-bundle.crt
+      - name: GIT_SSL_CAINFO
+        value: $(workspaces.source.path)/$(params.SUB_DIRECTORY)/.tekton-ca-bundle.crt
+    securityContext:
+      privileged: false
+      runAsNonRoot: true
+      runAsUser: 65532
+    # Requests only (no limits): give the scheduler sizing info without
+    # capping the variable footprint of packer runs / plugin downloads,
+    # which a too-low memory limit could OOM-kill.
+    computeResources:
+      requests:
+        cpu: 250m
+        memory: 256Mi
+  steps:
+    - name: trust-ca-certs
+      env:
+        - name: CA_CERTS_BOUND
+          value: $(workspaces.ca-certs.bound)
+        - name: CA_CERTS_PATH
+          value: $(workspaces.ca-certs.path)
+      script: |
+        #!/usr/bin/env sh
+        set -eu
+
+        # Build a combined CA bundle: system roots first, then any private
+        # CAs mounted via the ca-certs workspace. SSL_CERT_FILE (set in the
+        # stepTemplate) points every later step at this file. When no
+        # ca-certs workspace is bound the bundle equals the system store, so
+        # behaviour is unchanged.
+        BUNDLE="${SSL_CERT_FILE}"
+        : > "${BUNDLE}"
+
+        if [ -f /etc/ssl/certs/ca-certificates.crt ]; then
+          cat /etc/ssl/certs/ca-certificates.crt >> "${BUNDLE}"
+        fi
+
+        if [ "${CA_CERTS_BOUND}" = "true" ]; then
+          echo "Appending private CA certificates from ca-certs workspace"
+          found=0
+          for crt in "${CA_CERTS_PATH}"/*.crt "${CA_CERTS_PATH}"/*.pem; do
+            [ -f "${crt}" ] || continue
+            echo "  + ${crt}"
+            printf '\n' >> "${BUNDLE}"
+            cat "${crt}" >> "${BUNDLE}"
+            found=1
+          done
+          [ "${found}" = "0" ] && echo "  (no *.crt / *.pem files found)"
+        else
+          echo "No ca-certs workspace bound - using system trust store only"
+        fi
+
+        echo "CA bundle written to ${BUNDLE}"
+
+    - name: create-pkrvars
+      args:
+        - $(params.PKR_VARS[*])
+      script: |
+        #!/usr/bin/env sh
+        set -eu
+
+        echo "Creating tekton.auto.pkrvars.hcl"
+        rm -f ./tekton.auto.pkrvars.hcl
+        : > ./tekton.auto.pkrvars.hcl
+
+        for argument in "$@"; do
+          # Split on the FIRST '+-' only, so a value that itself contains
+          # '+-' is not mangled. Value typing is left to HCL (callers quote
+          # where a string is required, e.g. vm_name+-'ubuntu24').
+          echo "$argument" | sed -e "s/+-/ = /" >> ./tekton.auto.pkrvars.hcl
+        done
+
+        echo "Current tekton.auto.pkrvars.hcl contents:"
+        cat ./tekton.auto.pkrvars.hcl
+
+    - name: merge-pkrvars-file
+      env:
+        - name: PKR_VARS_FILE
+          value: $(params.PKR_VARS_FILE)
+      script: |
+        #!/usr/bin/env sh
+        set -eu
+
+        if [ -z "${PKR_VARS_FILE}" ]; then
+          echo "pkrvars file is empty - nothing to merge"
+        else
+          # Written as *.auto.pkrvars.hcl so packer auto-loads it. It is loaded
+          # alphabetically after tekton.auto.pkrvars.hcl, so its values take
+          # precedence over the per-key PKR_VARS above.
+          echo "Decoding pkrvars file from base64 -> zz-override.auto.pkrvars.hcl"
+          echo "${PKR_VARS_FILE}" | base64 -d > ./zz-override.auto.pkrvars.hcl
+          echo "Contents:"
+          cat ./zz-override.auto.pkrvars.hcl
+        fi
+
+    - name: packer-init
+      env:
+        - name: RUN_INIT
+          value: $(params.RUN_INIT)
+        - name: TEMPLATE
+          value: $(params.TEMPLATE)
+        - name: INIT_EXTRA_ARGS
+          value: $(params.INIT_EXTRA_ARGS)
+        - name: VAULT_ADDR
+          valueFrom:
+            secretKeyRef:
+              key: $(params.vault-secret-key-addr)
+              name: $(params.vault-secret-name)
+              optional: true
+        - name: VAULT_NAMESPACE
+          valueFrom:
+            secretKeyRef:
+              key: $(params.vault-secret-key-namespace)
+              name: $(params.vault-secret-name)
+              optional: true
+        - name: VAULT_ROLE_ID
+          valueFrom:
+            secretKeyRef:
+              key: $(params.vault-secret-key-approleId)
+              name: $(params.vault-secret-name)
+              optional: true
+        - name: VAULT_SECRET_ID
+          valueFrom:
+            secretKeyRef:
+              key: $(params.vault-secret-key-approleSecret)
+              name: $(params.vault-secret-name)
+              optional: true
+      envFrom:
+        - secretRef:
+            name: $(params.credentials-secret-name)
+            optional: true
+      script: |
+        #!/usr/bin/env sh
+        set -eu
+
+        if [ "${RUN_INIT}" != "true" ]; then
+          echo "Skipped packer init (RUN_INIT=${RUN_INIT})"
+          exit 0
+        fi
+
+        echo "=========================================="
+        echo "PACKER INIT"
+        echo "=========================================="
+        # INIT_EXTRA_ARGS is intentionally word-split.
+        # shellcheck disable=SC2086
+        packer init ${INIT_EXTRA_ARGS} "${TEMPLATE}"
+
+    - name: packer-action
+      env:
+        - name: ACTION
+          value: $(params.ACTION)
+        - name: TEMPLATE
+          value: $(params.TEMPLATE)
+        - name: ONLY
+          value: $(params.ONLY)
+        - name: FORCE
+          value: $(params.FORCE)
+        - name: BUILD_EXTRA_ARGS
+          value: $(params.BUILD_EXTRA_ARGS)
+        - name: VAULT_ADDR
+          valueFrom:
+            secretKeyRef:
+              key: $(params.vault-secret-key-addr)
+              name: $(params.vault-secret-name)
+              optional: true
+        - name: VAULT_NAMESPACE
+          valueFrom:
+            secretKeyRef:
+              key: $(params.vault-secret-key-namespace)
+              name: $(params.vault-secret-name)
+              optional: true
+        - name: VAULT_ROLE_ID
+          valueFrom:
+            secretKeyRef:
+              key: $(params.vault-secret-key-approleId)
+              name: $(params.vault-secret-name)
+              optional: true
+        - name: VAULT_SECRET_ID
+          valueFrom:
+            secretKeyRef:
+              key: $(params.vault-secret-key-approleSecret)
+              name: $(params.vault-secret-name)
+              optional: true
+      envFrom:
+        - secretRef:
+            name: $(params.credentials-secret-name)
+            optional: true
+      script: |
+        #!/usr/bin/env sh
+        set -eu
+
+        # Always declare the results so Tekton does not warn about unset
+        # results; the build branch overwrites artifact-id on success.
+        printf '%s' "$(params.ACTION)" > "$(results.action-performed.path)"
+        printf '' > "$(results.artifact-id.path)"
+
+        ONLY_FLAG=""
+        if [ -n "${ONLY}" ]; then
+          ONLY_FLAG="-only=${ONLY}"
+        fi
+
+        FORCE_FLAG=""
+        if [ "${FORCE}" = "true" ]; then
+          FORCE_FLAG="-force"
+        fi
+
+        echo "=========================================="
+        echo "PACKER ${ACTION}"
+        echo "=========================================="
+
+        case "${ACTION}" in
+          init)
+            echo "init already handled by the packer-init step - nothing to do"
+            ;;
+          validate)
+            # shellcheck disable=SC2086
+            packer validate ${ONLY_FLAG} ${BUILD_EXTRA_ARGS} "${TEMPLATE}"
+            ;;
+          build)
+            # shellcheck disable=SC2086
+            packer build -color=false ${FORCE_FLAG} ${ONLY_FLAG} ${BUILD_EXTRA_ARGS} "${TEMPLATE}"
+
+            # Best-effort: surface the last artifact id when the template uses
+            # the manifest post-processor (writes packer-manifest.json).
+            if [ -f packer-manifest.json ]; then
+              ARTIFACT=$(yq -p=json -o=tsv '.builds[-1].artifact_id // ""' packer-manifest.json 2>/dev/null || echo "")
+              printf '%s' "${ARTIFACT}" > "$(results.artifact-id.path)"
+              echo "artifact-id: ${ARTIFACT}"
+            else
+              echo "no packer-manifest.json found - artifact-id left empty"
+            fi
+            ;;
+          *)
+            echo "ERROR: unsupported ACTION '${ACTION}' (expected init, validate or build)" >&2
+            exit 1
+            ;;
+        esac
+
+        echo "=========================================="
+        echo "packer ${ACTION} completed successfully"
+        echo "=========================================="

--- a/tasks/execute-packer.yaml
+++ b/tasks/execute-packer.yaml
@@ -74,7 +74,7 @@ spec:
     - name: WORKING_IMAGE
       description: the image on which packer will run
       type: string
-      default: "ghcr.io/stuttgart-things/sthings-packer:1.12.0"
+      default: "ghcr.io/stuttgart-things/sthings-packer:1.15.1"
     - name: credentials-secret-name
       description: >-
         name of an optional secret whose keys are injected as environment
@@ -98,6 +98,10 @@ spec:
       description: namespace key in the secret
       type: string
       default: "VAULT_NAMESPACE"
+    - name: vault-secret-key-token
+      description: vault token key in the secret
+      type: string
+      default: "VAULT_TOKEN"
     - name: vault-secret-name
       description: name of the vault secret
       type: string
@@ -105,10 +109,11 @@ spec:
   results:
     - name: action-performed
       description: the packer action that was executed
-    - name: artifact-id
+    - name: template-name
       description: >-
-        best-effort artifact id of the last build, read from a
-        packer-manifest.json (manifest post-processor) if present; empty otherwise
+        name of the template/artifact produced by a build, parsed from packer's
+        artifact log line. A build that produces no artifact fails the task
+        (downstream promote/rename steps depend on this name)
   stepTemplate:
     workingDir: $(workspaces.source.path)/$(params.SUB_DIRECTORY)
     image: "$(params.WORKING_IMAGE)"
@@ -248,6 +253,12 @@ spec:
               key: $(params.vault-secret-key-approleSecret)
               name: $(params.vault-secret-name)
               optional: true
+        - name: VAULT_TOKEN
+          valueFrom:
+            secretKeyRef:
+              key: $(params.vault-secret-key-token)
+              name: $(params.vault-secret-name)
+              optional: true
       envFrom:
         - secretRef:
             name: $(params.credentials-secret-name)
@@ -304,18 +315,27 @@ spec:
               key: $(params.vault-secret-key-approleSecret)
               name: $(params.vault-secret-name)
               optional: true
+        - name: VAULT_TOKEN
+          valueFrom:
+            secretKeyRef:
+              key: $(params.vault-secret-key-token)
+              name: $(params.vault-secret-name)
+              optional: true
       envFrom:
         - secretRef:
             name: $(params.credentials-secret-name)
             optional: true
       script: |
-        #!/usr/bin/env sh
-        set -eu
+        #!/usr/bin/env bash
+        # bash (not sh): the build branch relies on PIPESTATUS to preserve
+        # packer's exit code through the `tee` pipe. The sthings-packer image
+        # ships bash.
+        set -euo pipefail
 
         # Always declare the results so Tekton does not warn about unset
-        # results; the build branch overwrites artifact-id on success.
+        # results; the build branch overwrites template-name on success.
         printf '%s' "$(params.ACTION)" > "$(results.action-performed.path)"
-        printf '' > "$(results.artifact-id.path)"
+        printf '' > "$(results.template-name.path)"
 
         ONLY_FLAG=""
         if [ -n "${ONLY}" ]; then
@@ -340,18 +360,32 @@ spec:
             packer validate ${ONLY_FLAG} ${BUILD_EXTRA_ARGS} "${TEMPLATE}"
             ;;
           build)
+            # Stream packer output live (tee) while keeping a copy to parse the
+            # produced template name from. PIPESTATUS preserves packer's exit
+            # code so a failed build is not masked by tee's success.
+            set +e
             # shellcheck disable=SC2086
-            packer build -color=false ${FORCE_FLAG} ${ONLY_FLAG} ${BUILD_EXTRA_ARGS} "${TEMPLATE}"
-
-            # Best-effort: surface the last artifact id when the template uses
-            # the manifest post-processor (writes packer-manifest.json).
-            if [ -f packer-manifest.json ]; then
-              ARTIFACT=$(yq -p=json -o=tsv '.builds[-1].artifact_id // ""' packer-manifest.json 2>/dev/null || echo "")
-              printf '%s' "${ARTIFACT}" > "$(results.artifact-id.path)"
-              echo "artifact-id: ${ARTIFACT}"
-            else
-              echo "no packer-manifest.json found - artifact-id left empty"
+            packer build -color=false ${FORCE_FLAG} ${ONLY_FLAG} ${BUILD_EXTRA_ARGS} "${TEMPLATE}" 2>&1 | tee /tmp/packer-build.log
+            rc=${PIPESTATUS[0]}
+            set -e
+            if [ "${rc}" -ne 0 ]; then
+              echo "ERROR: packer build failed (rc=${rc})" >&2
+              exit "${rc}"
             fi
+
+            # Parse the built template name from packer's artifact log line
+            # (e.g. `... artifact []string{"0", "id", "<template>"}`). No
+            # fabricated fallback: if no artifact was produced (no-op build or
+            # changed log format) we must FAIL, otherwise downstream
+            # promote/rename steps act on a template that does not exist.
+            TEMPLATE_NAME=$(sed -n 's/.*"0", "id", "\([^"]*\)".*/\1/p' /tmp/packer-build.log | tail -1)
+            if [ -z "${TEMPLATE_NAME}" ]; then
+              echo "ERROR: packer build finished but no template name could be extracted from the log." >&2
+              echo "ERROR: this means no artifact was produced (no-op build) or the log format changed." >&2
+              exit 1
+            fi
+            printf '%s' "${TEMPLATE_NAME}" > "$(results.template-name.path)"
+            echo "template-name: ${TEMPLATE_NAME}"
             ;;
           *)
             echo "ERROR: unsupported ACTION '${ACTION}' (expected init, validate or build)" >&2


### PR DESCRIPTION
Wraps Packer in the existing Tekton stack, mirroring `execute-tofu` / `execute-ansible`. Implements **layers 1 & 2** of #51 (the Crossplane `cicd/packer-build` Configuration — layer 3 — is a companion PR in `crossplane-configurations`).

## Layer 1 — Tekton + image
- **`images/packer/Dockerfile`** — `sthings-packer` image: packer **1.15.1** + `yq`, with the `vsphere`/`proxmox`/`qemu` plugins baked into the nonroot plugin dir so `packer init` resolves offline.
- **`tasks/execute-packer.yaml`** — `init`/`validate`/`build`; `PKR_VARS` → `*.auto.pkrvars.hcl`, b64 `PKR_VARS_FILE` override, optional `-only`/`-force`, per-run private-CA trust, `packer-credentials` + Vault (`VAULT_ADDR`/`ROLE_ID`/`SECRET_ID`/`TOKEN`) injection. Parses the built template name from packer's artifact log line and **fails hard if none is produced** (downstream promote/rename depends on it); exposed as the `template-name` result.
- **`pipelines/build-packer-template.yaml`** — `git-clone` → `execute-packer`, surfacing `template-name` as a pipeline-level result.
- **`.github/workflows/docker-build-packer.yaml`** — ttl.sh build-validate on PR; ghcr publish + crane `:sha`→`:version`/`:latest` promotion on merge.
- `tasks/README.md` — `EXECUTE PACKER` usage section.

## Layer 2 — KCL modules
- **`kcl/packer`** (`kcl-tekton-pr-packer`) — renders the PipelineRun from a `PackerBuild`-shaped input, optionally wrapped in a `kubernetes.m.crossplane.io/v1alpha1` Object. Keeps the **pipeline-definition repo** (stage-time) and **template-source repo** (`stuttgart-things/stuttgart-things`) as separate refs, and composes `gitWorkspaceSubdirectory` from `osVersion`+`lab`+`provisioning` (`packer/builds/<os>-<lab>-vsphere-<prov>`), mirroring the `dispatch-packer-build` action's `BUILD_DIR`.
- **`kcl/packer-run`** — client-side `PackerBuild` XR generator.
- Both added to the `kcl-validate` CI matrix.

## Design choice: direct packer, not dagger-in-Tekton
The existing GH-action build uses `dagger/packer bake`, which needs a BuildKit/dagger engine (the self-hosted runners have one). Running that in-cluster would require a privileged dind sidecar or external docker host — and would force a docker-engine precondition on every cluster the `cicd/packer-build` Configuration runs on. So this task runs `packer` directly (consistent with `execute-tofu`/`execute-ansible`), but aligned to the proven build (version, Vault wiring, log-based template-name extraction).

## Before this can go green
1. Merge `images/packer/**` so `sthings-packer` publishes to ghcr (the ttl.sh job also validates the plugin pins — my versions are a best guess).
2. `kcl mod push oci://ghcr.io/stuttgart-things/kcl-tekton-pr-packer` (tag `0.1.0`) from `kcl/packer` — the companion `cicd/packer-build` PR pins it.

## Not yet validated
`kcl` / `crossplane render` could not run in the authoring environment (network-restricted). The KCL modules are structural mirrors of the working ansible modules; the `kcl-validate` CI job is the gate.

Refs #51

https://claude.ai/code/session_01Vs6AFCDqLLj8SSomgqACVZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vs6AFCDqLLj8SSomgqACVZ)_