### PR TITLE
feat(kcl/ansible-run): expose userHome, vaultSecretName, inventory, varsFile

### DIFF
--- a/kcl/ansible-run/main.k
+++ b/kcl/ansible-run/main.k
@@ -47,6 +47,13 @@ _ansiblePlaybooks = _flat_params?.ansiblePlaybooks or option("ansiblePlaybooks")
 _ansibleVarsFile = _flat_params?.ansibleVarsFile or option("ansibleVarsFile") or []
 _ansibleVarsInventory = _flat_params?.ansibleVarsInventory or option("ansibleVarsInventory") or []
 _ansibleExtraCollections = _flat_params?.ansibleExtraCollections or option("ansibleExtraCollections") or []
+# Optional static inventory / vars file (base64 strings); empty means unset
+_inventory = _flat_params?.inventory or option("inventory") or ""
+_varsFile = _flat_params?.varsFile or option("varsFile") or ""
+
+# Runtime
+_userHome = _flat_params?.userHome or option("userHome") or "/home/nonroot"
+_vaultSecretName = _flat_params?.vaultSecretName or option("vaultSecretName") or "vault"
 
 # --- Generate AnsibleRun Resource ---
 _ansibleRun = schema.AnsibleRun {
@@ -66,6 +73,13 @@ _ansibleRun = schema.AnsibleRun {
         ansibleVarsFile = _ansibleVarsFile
         ansibleVarsInventory = _ansibleVarsInventory
         ansibleExtraCollections = _ansibleExtraCollections
+        userHome = _userHome
+        vaultSecretName = _vaultSecretName
+        # Only emit when set, so empty defaults don't appear in the XR
+        if _inventory:
+            inventory = _inventory
+        if _varsFile:
+            varsFile = _varsFile
     }
 }
 

--- a/kcl/ansible-run/schema.k
+++ b/kcl/ansible-run/schema.k
@@ -27,6 +27,11 @@ schema AnsibleRunSpec:
     ansibleVarsFile?: [str]
     ansibleVarsInventory?: [str]
     ansibleExtraCollections?: [str]
+    inventory?: str
+    varsFile?: str
+    # Runtime
+    userHome?: str
+    vaultSecretName?: str
 
 schema AnsibleRun:
     """


### PR DESCRIPTION
## What

The `kcl/ansible-run` XR generator emitted only a subset of the `AnsibleRun` spec. These four fields are accepted by the execute-ansible pipelines and resolved by the `kcl-tekton-pr` renderer, but the generator couldn't produce them.

### Changes
- Add `userHome`, `vaultSecretName`, `inventory`, `varsFile` to `schema.k`.
- Resolve them in `main.k` with the same precedence chain as the other fields.
  - `userHome` / `vaultSecretName` always emitted (defaults `/home/nonroot` / `vault`, matching the renderer).
  - `inventory` / `varsFile` emitted **only when set** (`if _inventory:` / `if _varsFile:`), so empty defaults stay out of the generated XR.

### Notes
- Companion PR in `crossplane-configurations` adds the matching fields to the `ansible-run` XRD (which is what actually makes them settable on a cluster).
- Client-side generator only — not published to OCI, no republish needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)