### PR TITLE
feat(ansible): optional SOPS decrypt after git clone + fix in-place truncation

### DIFF
--- a/pipelines/execute-ansible-playbooks.yaml
+++ b/pipelines/execute-ansible-playbooks.yaml
@@ -8,6 +8,11 @@ spec:
     - name: shared-workspace
     - name: sshCredentials
       optional: true
+    - name: sopsKeys
+      optional: true
+      description: >-
+        Optional workspace holding SOPS decryption keys (age key file and/or
+        PGP private key). Bound only when decryptSops is enabled.
   params:
     - name: ansibleExtraRoles
       type: array
@@ -98,10 +103,37 @@ spec:
       type: string
       default: "ANSIBLE_PASSWORD"
       description: key for ansible password in the secret
+    # -------------------------------
+    # SOPS decryption (runs after the git clone, before ansible)
+    # -------------------------------
+    - name: decryptSops
+      type: string
+      default: "false"
+      description: >-
+        When "true", decrypt SOPS-encrypted files from the cloned repo before
+        running ansible. Requires the sopsKeys workspace to be bound.
+    - name: sopsFiles
+      type: string
+      default: ""
+      description: >-
+        Whitespace-separated files to decrypt, relative to the shared workspace
+        root (e.g. "<gitWorkspaceSubdirectory>/secrets.sops.yaml"). Empty =>
+        every file matching sopsFilePattern.
+    - name: sopsFilePattern
+      type: string
+      default: "*.sops.yaml"
+      description: find(1) -name pattern used when sopsFiles is empty.
+    - name: sopsAgeKeyFile
+      type: string
+      default: "age.agekey"
+      description: >-
+        Name of the age key file inside the sopsKeys workspace (the
+        sops-secrets-operator project key secret exposes it as "age.agekey").
   tasks:
     - name: execute-ansible
       runAfter:
         - fetch-repository
+        - decrypt-sops
       taskRef:
         resolver: git
         params:
@@ -184,3 +216,41 @@ spec:
           value: $(params.gitWorkspaceSubdirectory)
         - name: url
           value: $(params.gitRepoUrl)
+    - name: decrypt-sops
+      runAfter:
+        - fetch-repository
+      when:
+        - input: $(params.decryptSops)
+          operator: in
+          values: ["true"]
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/stuttgart-things/stage-time.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/decrypt-sops.yaml
+      workspaces:
+        # Decrypt in place: read the cloned encrypted files from the shared
+        # workspace and write the plaintext back to the same paths so the
+        # ansible task (workingDir = <shared>/<gitWorkspaceSubdirectory>) reads
+        # the decrypted files.
+        - name: input
+          workspace: shared-workspace
+        - name: output
+          workspace: shared-workspace
+        - name: sops-keys
+          workspace: sopsKeys
+      params:
+        - name: files
+          value: $(params.sopsFiles)
+        - name: filePattern
+          value: $(params.sopsFilePattern)
+        - name: outputSubdirectory
+          value: ""
+        - name: ageKeyFile
+          value: $(params.sopsAgeKeyFile)
+        - name: verbose
+          value: "true"

--- a/tasks/decrypt-sops.yaml
+++ b/tasks/decrypt-sops.yaml
@@ -140,7 +140,15 @@ spec:
           dest="${OUTPUT_DIR}/${f}"
           mkdir -p "$(dirname "${dest}")"
           echo "Decrypting ${f} -> ${dest}"
-          sops --decrypt "${f}" > "${dest}"
+          # Decrypt to a temp file first, then move it into place. When the
+          # input and output workspaces are the same PVC (in-place decryption,
+          # e.g. decrypting cloned files where ansible later reads them), a
+          # direct `sops --decrypt ${f} > ${dest}` truncates ${dest} — which IS
+          # ${f} — to zero bytes before sops reads it, yielding "sops metadata
+          # not found". The temp file avoids clobbering the source.
+          tmp="$(mktemp)"
+          sops --decrypt "${f}" > "${tmp}"
+          mv "${tmp}" "${dest}"
         done
 
         echo "Decrypted files written to ${OUTPUT_DIR}:"


### PR DESCRIPTION
Wires the existing (previously unused) `decrypt-sops` task into `execute-ansible-playbooks.yaml` so encrypted files from the cloned repo can be decrypted **after the git clone, before ansible runs**, and fixes an in-place truncation bug in the task.

## Pipeline (`execute-ansible-playbooks.yaml`)
- optional `sopsKeys` workspace + params `decryptSops` (default `false`), `sopsFiles`, `sopsFilePattern` (`*.sops.yaml`), `sopsAgeKeyFile` (`age.agekey`)
- new `decrypt-sops` task `runAfter: [fetch-repository]`, gated `when: decryptSops == "true"`, decrypt in place (input=output=shared-workspace); `execute-ansible` now `runAfter: [fetch-repository, decrypt-sops]`

## Task fix (`decrypt-sops.yaml`)
With input==output (in-place), `sops --decrypt ${f} > ${dest}` (dest==f) truncated the source to 0 bytes before sops read it → `sops metadata not found`. Now decrypts to a `mktemp` file then `mv`s into place.

## Tested on kind1 (green)
git-clone(fixture) → decrypt-sops → verify: all Succeeded; file decrypted in place, marker present, no `ENC[]`. Age key = project key from the `sops-age-key` secret (data key `age.agekey`). Real pipeline passes `kubectl apply --dry-run=server`.

Follow-ups (tracked): pin git-resolver refs to a release tag (repo-wide + crossplane module), then KCL/crossplane wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)