### PR TITLE
chore: pin git-resolver self-refs to v0.7.0 (not main)

### DIFF
--- a/pipelines/build-image-buildah.yaml
+++ b/pipelines/build-image-buildah.yaml
@@ -88,7 +88,7 @@ spec:
           - name: url
             value: https://github.com/stuttgart-things/stage-time.git
           - name: revision
-            value: main
+            value: v0.7.0
           - name: pathInRepo
             value: tasks/build-buildah.yaml
       runAfter:

--- a/pipelines/build-packer-template.yaml
+++ b/pipelines/build-packer-template.yaml
@@ -120,7 +120,7 @@ spec:
           - name: url
             value: https://github.com/stuttgart-things/stage-time.git
           - name: revision
-            value: main
+            value: v0.7.0
           - name: pathInRepo
             value: tasks/execute-packer.yaml
       workspaces:

--- a/pipelines/execute-ansible-playbooks-from-collections.yaml
+++ b/pipelines/execute-ansible-playbooks-from-collections.yaml
@@ -100,7 +100,7 @@ spec:
           - name: url
             value: https://github.com/stuttgart-things/stage-time.git
           - name: revision
-            value: main
+            value: v0.7.0
           - name: pathInRepo
             value: tasks/execute-ansible.yaml
 

--- a/pipelines/execute-ansible-playbooks.yaml
+++ b/pipelines/execute-ansible-playbooks.yaml
@@ -140,7 +140,7 @@ spec:
           - name: url
             value: https://github.com/stuttgart-things/stage-time.git
           - name: revision
-            value: main
+            value: v0.7.0
           - name: pathInRepo
             value: tasks/execute-ansible.yaml
       workspaces:
@@ -229,7 +229,7 @@ spec:
           - name: url
             value: https://github.com/stuttgart-things/stage-time.git
           - name: revision
-            value: main
+            value: v0.7.0
           - name: pathInRepo
             value: tasks/decrypt-sops.yaml
       workspaces:


### PR DESCRIPTION
Pins all 5 stage-time `resolver: git` **self-references** in the pipelines from `revision: main` → `revision: v0.7.0`, so a task edit no longer silently changes every consumer (reproducibility / supply-chain — matching the already-pinned tektoncd/catalog git-clone ref).

Affected: build-image-buildah, build-packer-template, execute-ansible-playbooks-from-collections, execute-ansible-playbooks (execute-ansible + decrypt-sops).

The `v0.7.0` tag will be cut on the merge commit, so pipeline@v0.7.0 references task@v0.7.0 (same tagged commit). The crossplane KCL module (kcl-tekton-pr) will be pinned to v0.7.0 next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)