### PR TITLE
feat(kcl): pin pipelineRef to stage-time tag v0.7.0; split content vs pipeline source

### DIFF
--- a/kcl/ansible/kcl.mod
+++ b/kcl/ansible/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-tekton-pr"
 edition = "v0.11.2"
-version = "0.6.0"
+version = "0.7.0"
 
 [dependencies]
 tekton-pipelines = "1.0.0"

--- a/kcl/ansible/main.k
+++ b/kcl/ansible/main.k
@@ -26,6 +26,7 @@ _storageAccessModes = _flat_params?.storageAccessModes or option("storageAccessM
 _storageClass = _flat_params?.storageClass or _env?.storageClass or option("storageClass") or "openebs-hostpath"
 _namespace = _flat_params?.namespace or _env?.namespace or option("namespace") or "tekton-ci"
 _pipelineRunName = _flat_params?.pipelineRunName or option("pipelineRunName") or None
+
 # Ansible CONTENT source (what fetch-repository clones for the execute-ansible-
 # playbooks pipeline). This is the user's playbook repo/revision.
 _gitRepoUrl = _flat_params?.gitRepoUrl or _env?.gitRepoUrl or option("gitRepoUrl") or "https://github.com/stuttgart-things/stage-time.git"

--- a/kcl/ansible/main.k
+++ b/kcl/ansible/main.k
@@ -26,9 +26,19 @@ _storageAccessModes = _flat_params?.storageAccessModes or option("storageAccessM
 _storageClass = _flat_params?.storageClass or _env?.storageClass or option("storageClass") or "openebs-hostpath"
 _namespace = _flat_params?.namespace or _env?.namespace or option("namespace") or "tekton-ci"
 _pipelineRunName = _flat_params?.pipelineRunName or option("pipelineRunName") or None
+# Ansible CONTENT source (what fetch-repository clones for the execute-ansible-
+# playbooks pipeline). This is the user's playbook repo/revision.
 _gitRepoUrl = _flat_params?.gitRepoUrl or _env?.gitRepoUrl or option("gitRepoUrl") or "https://github.com/stuttgart-things/stage-time.git"
 _gitRevision = _flat_params?.gitRevision or _env?.gitRevision or option("gitRevision") or "main"
 _gitPath = _flat_params?.gitPath or _env?.gitPath or option("gitPath") or "pipelines/execute-ansible-playbooks-from-collections.yaml"
+
+# Pipeline DEFINITION source for the PipelineRun's `pipelineRef` git resolver —
+# i.e. where the Tekton Pipeline YAML at `_gitPath` lives. Pinned to a stage-time
+# release TAG (not `main`) for reproducibility/supply-chain safety; kept separate
+# from the content source above so pointing gitRepoUrl at an external playbook repo
+# no longer drags the pipeline definition with it.
+_pipelineRepoUrl = _flat_params?.pipelineRepoUrl or _env?.pipelineRepoUrl or option("pipelineRepoUrl") or "https://github.com/stuttgart-things/stage-time.git"
+_pipelineRevision = _flat_params?.pipelineRevision or _env?.pipelineRevision or option("pipelineRevision") or "v0.7.0"
 _ansibleWorkingImage = _flat_params?.ansibleWorkingImage or _env?.ansibleWorkingImage or option("ansibleWorkingImage") or "ghcr.io/stuttgart-things/sthings-ansible:11.11.0"
 _ansiblePlaybooks = _flat_params?.ansiblePlaybooks or option("ansiblePlaybooks") or ["sthings.baseos.setup"]
 _ansibleExtraCollections = _flat_params?.ansibleExtraCollections or _env?.ansibleExtraCollections or option("ansibleExtraCollections") or []
@@ -83,8 +93,8 @@ _suffix = crypto.md5(_timestamp)[:8:]
 
 # --- Override configurations with extracted params ---
 _git_config_override = {
-    url = _gitRepoUrl
-    revision = _gitRevision
+    url = _pipelineRepoUrl
+    revision = _pipelineRevision
     pathInRepo = _gitPath
 }
 

--- a/pipelines/build-image-buildah.yaml
+++ b/pipelines/build-image-buildah.yaml
@@ -88,7 +88,7 @@ spec:
           - name: url
             value: https://github.com/stuttgart-things/stage-time.git
           - name: revision
-            value: main
+            value: v0.7.0
           - name: pathInRepo
             value: tasks/build-buildah.yaml
       runAfter:

--- a/pipelines/build-packer-template.yaml
+++ b/pipelines/build-packer-template.yaml
@@ -120,7 +120,7 @@ spec:
           - name: url
             value: https://github.com/stuttgart-things/stage-time.git
           - name: revision
-            value: main
+            value: v0.7.0
           - name: pathInRepo
             value: tasks/execute-packer.yaml
       workspaces:

--- a/pipelines/execute-ansible-playbooks-from-collections.yaml
+++ b/pipelines/execute-ansible-playbooks-from-collections.yaml
@@ -100,7 +100,7 @@ spec:
           - name: url
             value: https://github.com/stuttgart-things/stage-time.git
           - name: revision
-            value: main
+            value: v0.7.0
           - name: pathInRepo
             value: tasks/execute-ansible.yaml
 

--- a/pipelines/execute-ansible-playbooks.yaml
+++ b/pipelines/execute-ansible-playbooks.yaml
@@ -140,7 +140,7 @@ spec:
           - name: url
             value: https://github.com/stuttgart-things/stage-time.git
           - name: revision
-            value: main
+            value: v0.7.0
           - name: pathInRepo
             value: tasks/execute-ansible.yaml
       workspaces:
@@ -229,7 +229,7 @@ spec:
           - name: url
             value: https://github.com/stuttgart-things/stage-time.git
           - name: revision
-            value: main
+            value: v0.7.0
           - name: pathInRepo
             value: tasks/decrypt-sops.yaml
       workspaces:


### PR DESCRIPTION
Pins the crossplane module's PipelineRun `pipelineRef` git resolver to the **v0.7.0** tag (not `main`), and splits the conflated pipeline-definition source from the ansible-content source.

- New `_pipelineRepoUrl` / `_pipelineRevision` (default `stage-time` / `v0.7.0`) drive the `pipelineRef`.
- `_gitRepoUrl` / `_gitRevision` now solely drive the ansible-content clone (fetch-repository).
- Bumps `kcl-tekton-pr` `0.6.0` → `0.7.0` (published to OCI after merge; composition pin bumped separately in crossplane-configurations).

Render verified: `pipelineRef.revision: v0.7.0`, content params unchanged (stage-time/main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)