### PR TITLE
fix(kcl-tekton-pr): don't claim Update on one-shot PipelineRuns (0.9.0)

### DIFF
--- a/kcl/ansible/kcl.mod
+++ b/kcl/ansible/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-tekton-pr"
 edition = "v0.11.2"
-version = "0.8.0"
+version = "0.9.0"
 
 [dependencies]
 tekton-pipelines = "1.0.0"

--- a/kcl/ansible/main.k
+++ b/kcl/ansible/main.k
@@ -198,6 +198,12 @@ _crossplaneObject = {
         }
     }
     spec = {
+        # A PipelineRun is one-shot and Tekton rejects any spec update once it
+        # completes. The default ["*"] claims Update, so provider-kubernetes'
+        # observe dry-run SSA gets denied by the webhook, the observe errors and
+        # the finalizer is never released — deleting the XR after a successful
+        # run strands the Object forever. Create it, watch it, never touch it.
+        managementPolicies = ["Observe", "Create"]
         forProvider = {
             manifest = _pipelineRun
         }


### PR DESCRIPTION
Fixes #59.

## The bug

The Crossplane `Object` wrapper in `kcl/ansible/main.k` set no `managementPolicies`, so it defaulted to `["*"]` — full control, **including Update**. A Tekton `PipelineRun` is one-shot and Tekton makes it immutable once it completes, so provider-kubernetes' observe dry-run SSA gets rejected:

```
observe failed: cannot get desired state: cannot dry run SSA: admission webhook
"validation.webhook.pipeline.tekton.dev" denied the request: validation failed:
invalid value: Once the PipelineRun is complete, no updates are allowed: spec
```

Observe errors → the finalizer is never released → **deleting an `AnsibleRun` XR after a successful run strands the `Object` forever**. On kind1, three of them sat in deletion for 22h+ and only a manual finalizer patch cleared them. This hits every `AnsibleRun` deleted after a completed run, so they accumulate.

## The fix

```python
managementPolicies = ["Observe", "Create"]
```

Create it, watch it, never touch it again — the same pattern `crossplane-configurations/CLAUDE.md` prescribes for adopted namespaces. Bumps the module to `0.9.0`.

## Verification

Measured on kind1 against an **already-completed** PipelineRun (`container-kindtest-032`, Succeeded 2d prior) — not reasoned, probed:

| | default `["*"]` (today) | `["Observe","Create"]` |
|---|---|---|
| Observe a completed PipelineRun | dry-run SSA → webhook denied, `Synced=False` | `Synced=True`, `Ready=True` |
| Delete the Object | **stuck 22h+** | **0.34 s** |
| Underlying PipelineRun | — | preserved |

Render checks:
- Composition mode emits the Object with `managementPolicies: ['Observe', 'Create']`, `providerConfigRef`, `forProvider.manifest.kind: PipelineRun` intact.
- **Standalone mode is unchanged** — a bare `PipelineRun`, zero `managementPolicies` in the output. The policies only exist on the Object wrapper.
- `kcl fmt` clean, `kcl lint` clean.

## Behaviour change worth a second opinion

The PipelineRun is now **left behind** when the XR is deleted (no `Delete` policy). For run history that seems right — completed runs are a record and Tekton pruning owns their lifecycle. If they should instead die with the XR, the policy would need `["Observe", "Create", "Delete"]`, and I did **not** verify that this still avoids the update dry-run. Say the word and I'll test it before this merges.

## Rollout

- This repo has **no auto-publish** (`kcl-validate.yaml` validates on PRs only, no `mod push`), so `kcl-tekton-pr:0.9.0` needs a manual `kcl mod push` to ghcr after merge.
- Then bump `cicd/ansible-run` in `stuttgart-things/crossplane-configurations` from `kcl-tekton-pr:0.8.0` to `0.9.0`.
- Existing stuck Objects are **not** healed by this; they still need
  `kubectl patch objects.kubernetes.m.crossplane.io <name> -n <ns> --type=merge -p '{"metadata":{"finalizers":[]}}'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
