### PR TITLE
chore(gitignore): ignore local KCL OCI pull cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,8 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+# Local KCL OCI pull cache — `kcl mod push`/`add` unpacks fetched modules
+# next to the module it ran in (e.g. kcl/ansible/oci/ghcr.io/...). Build
+# artifact, never source.
+kcl/**/oci/


### PR DESCRIPTION
`kcl mod push` / `kcl mod add` unpack fetched modules into an `oci/` directory next to the module they ran in. Right now `kcl/ansible/oci/ghcr.io/stuttgart-things/kcl-tekton-pr:0.6.0/` sits untracked in the working tree — left over from publishing `kcl-tekton-pr`.

It's a build artifact, not source, so it just adds noise to `git status` after every module publish (and could get committed by accident on a wide `git add`). The existing `.gitignore` is still purely Terraform-era and doesn't cover it.

```console
$ git check-ignore -v kcl/ansible/oci/.../main.k
.gitignore:44:kcl/**/oci/   kcl/ansible/oci/.../main.k
```

`kcl.mod.lock` files stay tracked — those are source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZGp1xCtkmsDb8a35iwBUG