### PR TITLE
fix(packer): parse artifact name from -machine-readable, not the debug log

### DIFF
--- a/kcl/ansible/kcl.mod
+++ b/kcl/ansible/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-tekton-pr"
 edition = "v0.11.2"
-version = "0.9.0"
+version = "0.10.0"
 
 [dependencies]
 tekton-pipelines = "1.0.0"

--- a/kcl/ansible/main.k
+++ b/kcl/ansible/main.k
@@ -39,7 +39,7 @@ _gitPath = _flat_params?.gitPath or _env?.gitPath or option("gitPath") or "pipel
 # from the content source above so pointing gitRepoUrl at an external playbook repo
 # no longer drags the pipeline definition with it.
 _pipelineRepoUrl = _flat_params?.pipelineRepoUrl or _env?.pipelineRepoUrl or option("pipelineRepoUrl") or "https://github.com/stuttgart-things/stage-time.git"
-_pipelineRevision = _flat_params?.pipelineRevision or _env?.pipelineRevision or option("pipelineRevision") or "v0.7.0"
+_pipelineRevision = _flat_params?.pipelineRevision or _env?.pipelineRevision or option("pipelineRevision") or "v0.8.0"
 
 # SOPS decrypt-after-git-clone (execute-ansible-playbooks pipeline only). Off by
 # default. When "true", the sops params are passed AND the sopsKeys workspace is

--- a/pipelines/build-image-buildah.yaml
+++ b/pipelines/build-image-buildah.yaml
@@ -88,7 +88,7 @@ spec:
           - name: url
             value: https://github.com/stuttgart-things/stage-time.git
           - name: revision
-            value: v0.7.0
+            value: v0.8.0
           - name: pathInRepo
             value: tasks/build-buildah.yaml
       runAfter:

--- a/pipelines/build-packer-template.yaml
+++ b/pipelines/build-packer-template.yaml
@@ -120,7 +120,7 @@ spec:
           - name: url
             value: https://github.com/stuttgart-things/stage-time.git
           - name: revision
-            value: v0.7.0
+            value: v0.8.0
           - name: pathInRepo
             value: tasks/execute-packer.yaml
       workspaces:

--- a/pipelines/execute-ansible-playbooks-from-collections.yaml
+++ b/pipelines/execute-ansible-playbooks-from-collections.yaml
@@ -100,7 +100,7 @@ spec:
           - name: url
             value: https://github.com/stuttgart-things/stage-time.git
           - name: revision
-            value: v0.7.0
+            value: v0.8.0
           - name: pathInRepo
             value: tasks/execute-ansible.yaml
 

--- a/pipelines/execute-ansible-playbooks.yaml
+++ b/pipelines/execute-ansible-playbooks.yaml
@@ -140,7 +140,7 @@ spec:
           - name: url
             value: https://github.com/stuttgart-things/stage-time.git
           - name: revision
-            value: v0.7.0
+            value: v0.8.0
           - name: pathInRepo
             value: tasks/execute-ansible.yaml
       workspaces:
@@ -229,7 +229,7 @@ spec:
           - name: url
             value: https://github.com/stuttgart-things/stage-time.git
           - name: revision
-            value: v0.7.0
+            value: v0.8.0
           - name: pathInRepo
             value: tasks/decrypt-sops.yaml
       workspaces:

--- a/tasks/execute-packer.yaml
+++ b/tasks/execute-packer.yaml
@@ -360,12 +360,33 @@ spec:
             packer validate ${ONLY_FLAG} ${BUILD_EXTRA_ARGS} "${TEMPLATE}"
             ;;
           build)
-            # Stream packer output live (tee) while keeping a copy to parse the
-            # produced template name from. PIPESTATUS preserves packer's exit
-            # code so a failed build is not masked by tee's success.
+            # -machine-readable gives a stable, parseable event stream on
+            # stdout (`<ts>,<target>,artifact,<idx>,id,<name>`). The previous
+            # approach parsed the same events out of packer's *debug log*,
+            # which packer only writes when PACKER_LOG is set - so with the
+            # default PACKER_LOG="" no name was ever found and every
+            # successful build failed the task.
+            #
+            # -machine-readable suppresses the human-readable output, so the
+            # awk below re-renders the `ui` events live to keep the TaskRun
+            # log readable. stderr is deliberately NOT merged into the pipe:
+            # it carries packer's own errors and any PACKER_LOG debug output,
+            # which would otherwise be swallowed by the renderer.
+            #
+            # PIPESTATUS[0] preserves packer's exit code so a failed build is
+            # not masked by the success of tee/awk.
             set +e
             # shellcheck disable=SC2086
-            packer build -color=false ${FORCE_FLAG} ${ONLY_FLAG} ${BUILD_EXTRA_ARGS} "${TEMPLATE}" 2>&1 | tee /tmp/packer-build.log
+            packer build -machine-readable ${FORCE_FLAG} ${ONLY_FLAG} ${BUILD_EXTRA_ARGS} "${TEMPLATE}" \
+              | tee /tmp/packer-build.log \
+              | awk -F, '$3 == "ui" {
+                  line = $5
+                  for (i = 6; i <= NF; i++) line = line "," $i
+                  gsub(/%!\(PACKER_COMMA\)/, ",", line)
+                  gsub(/\\n/, "\n", line)
+                  gsub(/\\r/, "", line)
+                  print line
+                }'
             rc=${PIPESTATUS[0]}
             set -e
             if [ "${rc}" -ne 0 ]; then
@@ -373,12 +394,18 @@ spec:
               exit "${rc}"
             fi
 
-            # Parse the built template name from packer's artifact log line
-            # (e.g. `... artifact []string{"0", "id", "<template>"}`). No
+            # Pull the artifact id out of the machine-readable stream. No
             # fabricated fallback: if no artifact was produced (no-op build or
-            # changed log format) we must FAIL, otherwise downstream
+            # changed event format) we must FAIL, otherwise downstream
             # promote/rename steps act on a template that does not exist.
-            TEMPLATE_NAME=$(sed -n 's/.*"0", "id", "\([^"]*\)".*/\1/p' /tmp/packer-build.log | tail -1)
+            # tail -1 keeps the last artifact when -only matched several
+            # sources, matching the previous behaviour.
+            TEMPLATE_NAME=$(awk -F, '$3 == "artifact" && $5 == "id" {
+                v = $6
+                for (i = 7; i <= NF; i++) v = v "," $i
+                gsub(/%!\(PACKER_COMMA\)/, ",", v)
+                print v
+              }' /tmp/packer-build.log | tail -1)
             if [ -z "${TEMPLATE_NAME}" ]; then
               echo "ERROR: packer build finished but no template name could be extracted from the log." >&2
               echo "ERROR: this means no artifact was produced (no-op build) or the log format changed." >&2


### PR DESCRIPTION
## Problem

`execute-packer` parsed the built template name out of packer's **debug log** line:

```
artifact []string{"0", "id", "<name>"}
```

Packer only writes those events to the log when `PACKER_LOG` is set — but the `packerLog` param defaults to `""`. So no name was ever extracted, and every **successful** build failed the task with:

```
ERROR: packer build finished but no template name could be extracted from the log.
```

This path had never been run on a cluster, so it went unnoticed.

## Fix

Use `packer build -machine-readable` and parse the stable event stream (`<ts>,<target>,artifact,<idx>,id,<name>`).

Two details worth review:

- **`-machine-readable` suppresses human output**, so an `awk` stage re-renders the `ui` events. The TaskRun log came out byte-identical to before.
- **stderr is deliberately not merged into the pipe.** With `2>&1`, packer's own errors and any `PACKER_LOG` debug output would fail the `$3 == "ui"` match and be silently dropped.

Commas and newlines that packer escapes (`%!(PACKER_COMMA)`, `\n`) are unescaped in both the renderer and the parser.

## Verification

Run on a kind cluster against a null-builder fixture template:

| Check | Result |
|---|---|
| `build` with default `packerLog: ""` (the original failure) | Succeeded, `result template-name=Null` |
| TaskRun log readability | identical to previous human output |
| Failing build (`exit 3` provisioner) | error lines render, `PIPESTATUS[0]` propagates non-zero |
| `PACKER_LOG=1` still set | debug output still visible, parse still works |
| Image pulled from a real registry (ttl.sh) | Succeeded |

## Pin bump

Bumps the stage-time git-resolver self-refs `v0.7.0` → `v0.8.0` so the pipelines resolve the fixed task, keeping all pins uniform (per 7f2182a). **The `v0.8.0` tag must be cut on the merge commit or these pipelines will fail to resolve.**

`kcl-tekton-pr` goes to `0.10.0` for the changed `pipelineRevision` default. Per its CLAUDE.md that still needs a manual `kcl mod push` and a pin bump in `crossplane-configurations` → `cicd/ansible-run`.

## Still open (not in this PR)

- `ghcr.io/stuttgart-things/sthings-packer:1.15.1` is **unpublished** — GHCR only has `1.11.2`, `1.11.2-10.4.0`, `1.23`. Referenced in 3 places, so any run using defaults fails to pull.
- The default `gitRepoUrl` (`stuttgart-things/stuttgart-things`) 404s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TrLpL4ziRqUDZeTqeMyuF