### PR TITLE
ci(packer): allow publish job to run via workflow_dispatch

### DIFF
--- a/.github/workflows/docker-build-packer.yaml
+++ b/.github/workflows/docker-build-packer.yaml
@@ -81,7 +81,13 @@ jobs:
   # :latest (promotion, no rebuild).
   publish:
     name: publish (ghcr)
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # workflow_dispatch is allowed (still gated on main) so a failed publish
+    # can be retried without a dummy commit. GitHub refuses to re-run a
+    # workflow run older than a month, which left :1.15.1 unpublished after
+    # the 2026-06-15 run failed with `denied: permission_denied: write_package`.
+    if: >-
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+      && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Why

`ghcr.io/stuttgart-things/sthings-packer:1.15.1` — the default `packerWorkingImage` in three places — **has never been published.** The publish job failed on 2026-06-15 ([run 27576201826](https://github.com/stuttgart-things/stage-time/actions/runs/27576201826)):

```
403 Forbidden
denied: permission_denied: write_package
```

and was never retried. By the time it was noticed, GitHub refused: *"Unable to retry this workflow run because it was created over a month ago."* The job only fires on push-to-main, so there was no retry path short of a dummy commit.

## Change

Allow `workflow_dispatch` to run the publish job, still gated on `refs/heads/main` so a dispatch cannot publish from a branch.

## This alone does NOT fix the 403

The root cause is a **per-package access grant**, not workflow permissions — `permissions: packages: write` was already correct and byte-identical to `docker-build.yaml`:

| Package | Owning repo | stage-time can write? |
|---|---|---|
| `sthings-ansible` | `stuttgart-things/stuttgart-things` | ✅ publishes fine |
| `sthings-packer` | `stuttgart-things/stuttgart-things` | ❌ 403 |

Both packages were created 2024-09-22 under the old repo. `sthings-ansible` has `stage-time` granted write access; `sthings-packer` never did.

**Required before publish can succeed:** org owner adds `stage-time` under
[sthings-packer → Manage Actions access](https://github.com/orgs/stuttgart-things/packages/container/sthings-packer/settings) with role **Write**.

Once that's done, merging this PR triggers the publish itself (the workflow file is in the trigger `paths`), or it can be dispatched manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TrLpL4ziRqUDZeTqeMyuF