### PR TITLE
fix(packer): make real template builds work (private repo, subdir, plugin persistence)

### DIFF
--- a/kcl/packer/kcl.mod
+++ b/kcl/packer/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-tekton-pr-packer"
 edition = "v0.11.2"
-version = "0.1.0"
+version = "0.2.0"
 
 [dependencies]
 tekton-pipelines = "1.0.0"

--- a/kcl/packer/main.k
+++ b/kcl/packer/main.k
@@ -38,6 +38,7 @@ _pipelinePath = _flat_params?.pipelinePath or _env?.pipelinePath or option("pipe
 # --- Template SOURCE repo (the .pkr.hcl templates the pipeline checks out) ---
 _gitRepoUrl = _flat_params?.gitRepoUrl or _env?.gitRepoUrl or option("gitRepoUrl") or "https://github.com/stuttgart-things/stuttgart-things.git"
 _gitRevision = _flat_params?.gitRevision or option("gitRevision") or "main"
+
 # Name of a secret holding .gitconfig / .git-credentials (see
 # templates/git-basicauth-secret.yaml). Required to clone the default
 # gitRepoUrl, which is a private repo — an https:// remote cannot be

--- a/kcl/packer/main.k
+++ b/kcl/packer/main.k
@@ -38,6 +38,11 @@ _pipelinePath = _flat_params?.pipelinePath or _env?.pipelinePath or option("pipe
 # --- Template SOURCE repo (the .pkr.hcl templates the pipeline checks out) ---
 _gitRepoUrl = _flat_params?.gitRepoUrl or _env?.gitRepoUrl or option("gitRepoUrl") or "https://github.com/stuttgart-things/stuttgart-things.git"
 _gitRevision = _flat_params?.gitRevision or option("gitRevision") or "main"
+# Name of a secret holding .gitconfig / .git-credentials (see
+# templates/git-basicauth-secret.yaml). Required to clone the default
+# gitRepoUrl, which is a private repo — an https:// remote cannot be
+# authenticated by the sshCredentials workspace. Empty = workspace unbound.
+_gitBasicAuthSecretName = _flat_params?.gitBasicAuthSecretName or _env?.gitBasicAuthSecretName or option("gitBasicAuthSecretName") or ""
 
 # Higher-level build selectors, mirroring the dispatch-packer-build action's
 # BUILD_DIR = packer/builds/<os>-<lab>-vsphere-<provisioning>. When
@@ -113,6 +118,16 @@ _workspace_config_override = {
     }
 }
 
+# Optional basic-auth workspace for cloning a private template repo over
+# HTTPS. Only emitted when a secret name is given, so the pipeline's
+# `basicAuth` workspace stays unbound (and optional) by default.
+_basicAuthWorkspaces = [
+    {
+        name = "basicAuth"
+        secret = {secretName = _gitBasicAuthSecretName}
+    }
+] if _gitBasicAuthSecretName else []
+
 # Pipeline params — keys must match build-packer-template.yaml's param names.
 _pipeline_params_override = {
     packerAction = _packerAction
@@ -148,7 +163,7 @@ _pipelineRun = tekton.PipelineRun {
         params = [{name = k, value = v} for k, v in _pipeline_params_override]
         taskRunTemplate = vars._task_run_template
         timeouts = vars._timeouts
-        workspaces = [_workspace_config_override]
+        workspaces = [_workspace_config_override] + _basicAuthWorkspaces
     }
 }
 

--- a/pipelines/build-packer-template.yaml
+++ b/pipelines/build-packer-template.yaml
@@ -8,6 +8,12 @@ spec:
     - name: shared-workspace
     - name: sshCredentials
       optional: true
+    # Credentials for cloning the template repo over HTTPS (the default
+    # gitRepoUrl is a private repo, and an ssh-directory cannot authenticate
+    # an https:// remote). Expects a secret with .gitconfig / .git-credentials
+    # as produced by templates/git-basicauth-secret.yaml.
+    - name: basicAuth
+      optional: true
     - name: caCerts
       optional: true
   params:
@@ -78,7 +84,11 @@ spec:
     - name: gitWorkspaceSubdirectory
       type: string
       default: ""
-      description: subdirectory on workspace
+      description: >-
+        path INSIDE the template repo holding the *.pkr.hcl (e.g.
+        packer/builds/ubuntu24-labul-vsphere-base-os). Empty => repo root.
+        This is not a workspace-placement path; the repo is always cloned to
+        the workspace root.
   results:
     - name: template-name
       description: name of the template/artifact produced by the build
@@ -102,13 +112,21 @@ spec:
           workspace: shared-workspace
         - name: ssh-directory
           workspace: sshCredentials
+        - name: basic-auth
+          workspace: basicAuth
       params:
         - name: deleteExisting
           value: 'true'
         - name: revision
           value: $(params.gitRevision)
-        - name: subdirectory
-          value: $(params.gitWorkspaceSubdirectory)
+        # NOTE: gitWorkspaceSubdirectory is deliberately NOT passed as
+        # git-clone's `subdirectory`. It is a REPO-RELATIVE path (where the
+        # *.pkr.hcl live inside the template repo, e.g.
+        # packer/builds/<os>-<lab>-<hypervisor>-<provisioning>) and is applied
+        # by execute-packer as SUB_DIRECTORY. Passing it here too nested the
+        # clone under the same path, so the packer working dir landed on the
+        # repo ROOT and every real build failed with
+        # "Could not find any config file in .".
         - name: url
           value: $(params.gitRepoUrl)
     - name: execute-packer

--- a/tasks/execute-packer.yaml
+++ b/tasks/execute-packer.yaml
@@ -221,64 +221,14 @@ spec:
           cat ./zz-override.auto.pkrvars.hcl
         fi
 
-    - name: packer-init
-      env:
-        - name: RUN_INIT
-          value: $(params.RUN_INIT)
-        - name: TEMPLATE
-          value: $(params.TEMPLATE)
-        - name: INIT_EXTRA_ARGS
-          value: $(params.INIT_EXTRA_ARGS)
-        - name: VAULT_ADDR
-          valueFrom:
-            secretKeyRef:
-              key: $(params.vault-secret-key-addr)
-              name: $(params.vault-secret-name)
-              optional: true
-        - name: VAULT_NAMESPACE
-          valueFrom:
-            secretKeyRef:
-              key: $(params.vault-secret-key-namespace)
-              name: $(params.vault-secret-name)
-              optional: true
-        - name: VAULT_ROLE_ID
-          valueFrom:
-            secretKeyRef:
-              key: $(params.vault-secret-key-approleId)
-              name: $(params.vault-secret-name)
-              optional: true
-        - name: VAULT_SECRET_ID
-          valueFrom:
-            secretKeyRef:
-              key: $(params.vault-secret-key-approleSecret)
-              name: $(params.vault-secret-name)
-              optional: true
-        - name: VAULT_TOKEN
-          valueFrom:
-            secretKeyRef:
-              key: $(params.vault-secret-key-token)
-              name: $(params.vault-secret-name)
-              optional: true
-      envFrom:
-        - secretRef:
-            name: $(params.credentials-secret-name)
-            optional: true
-      script: |
-        #!/usr/bin/env sh
-        set -eu
-
-        if [ "${RUN_INIT}" != "true" ]; then
-          echo "Skipped packer init (RUN_INIT=${RUN_INIT})"
-          exit 0
-        fi
-
-        echo "=========================================="
-        echo "PACKER INIT"
-        echo "=========================================="
-        # INIT_EXTRA_ARGS is intentionally word-split.
-        # shellcheck disable=SC2086
-        packer init ${INIT_EXTRA_ARGS} "${TEMPLATE}"
-
+    # init and the validate/build action MUST share one step. Tekton runs each
+    # step in its own container, and `packer init` installs plugins into
+    # $HOME/.config/packer/plugins - which is image-local, not a shared volume.
+    # As separate steps, init downloaded the plugin and the next step then died
+    # with "Missing plugins ... Did you run packer init for this project?".
+    # Pointing PACKER_PLUGIN_PATH at the workspace is NOT an alternative: it
+    # replaces (rather than extends) the search path, hiding the vsphere /
+    # proxmox / qemu plugins baked into the image.
     - name: packer-action
       env:
         - name: ACTION
@@ -289,6 +239,10 @@ spec:
           value: $(params.ONLY)
         - name: FORCE
           value: $(params.FORCE)
+        - name: RUN_INIT
+          value: $(params.RUN_INIT)
+        - name: INIT_EXTRA_ARGS
+          value: $(params.INIT_EXTRA_ARGS)
         - name: BUILD_EXTRA_ARGS
           value: $(params.BUILD_EXTRA_ARGS)
         - name: VAULT_ADDR
@@ -337,6 +291,21 @@ spec:
         printf '%s' "$(params.ACTION)" > "$(results.action-performed.path)"
         printf '' > "$(results.template-name.path)"
 
+        # `packer init` first, in THIS container, so the plugins it installs
+        # are visible to the validate/build below. ACTION=init always inits -
+        # otherwise `ACTION=init RUN_INIT=false` would report success having
+        # done nothing at all.
+        if [ "${RUN_INIT}" = "true" ] || [ "${ACTION}" = "init" ]; then
+          echo "=========================================="
+          echo "PACKER INIT"
+          echo "=========================================="
+          # INIT_EXTRA_ARGS is intentionally word-split.
+          # shellcheck disable=SC2086
+          packer init ${INIT_EXTRA_ARGS} "${TEMPLATE}"
+        else
+          echo "Skipped packer init (RUN_INIT=${RUN_INIT})"
+        fi
+
         ONLY_FLAG=""
         if [ -n "${ONLY}" ]; then
           ONLY_FLAG="-only=${ONLY}"
@@ -353,7 +322,7 @@ spec:
 
         case "${ACTION}" in
           init)
-            echo "init already handled by the packer-init step - nothing to do"
+            echo "init already handled above - nothing to do"
             ;;
           validate)
             # shellcheck disable=SC2086


### PR DESCRIPTION
Three bugs that together made every real packer build impossible. All stayed invisible until now — the only runs that ever reached this stage used a public fixture repo, cloned to the workspace root, needing no plugins.

## 1. No way to clone a private template repo

The default `gitRepoUrl` (`stuttgart-things/stuttgart-things`) is **private**, `main.k:71` asserts it must be `https://github.com/...`, and the pipeline wired only git-clone's `ssh-directory` — which cannot authenticate an `https://` remote. There was no credential path at all.

Wires git-clone's `basic-auth` workspace (as `build-image-buildah.yaml` already does) and exposes it as the optional `basicAuth` pipeline workspace. `kcl/packer` gains `gitBasicAuthSecretName`, emitting the binding only when set so the workspace stays unbound by default.

## 2. `gitWorkspaceSubdirectory` was applied twice

It's a **repo-relative** path (where the `*.pkr.hcl` live inside the template repo) and is already applied by `execute-packer` as `SUB_DIRECTORY`. Passing it to git-clone as `subdirectory` too nested the clone under the same path:

```
<ws>/packer/builds/ubuntu24-labul-vsphere-base-os/   <- git-clone put the repo ROOT here
    packer/builds/ubuntu24-labul-vsphere-base-os/    <- where the templates actually are
```

So the packer working dir landed on the repo root and every build failed with `Could not find any config file in .` — i.e. exactly what the `osVersion`/`lab`/`provisioning` selectors compose. Dropped from git-clone; the repo is always cloned to the workspace root, and the param description now says so.

Note `execute-ansible-playbooks.yaml` passes the same param to both consumers but is **self-consistent** (clone dir and task workingDir are the same path), so it is deliberately left alone.

## 3. `packer init` plugins didn't survive to validate/build

Tekton runs each step in its own container, and `packer init` installs into `$HOME/.config/packer/plugins` — image-local, not a shared volume. The separate `packer-init` step downloaded the plugin and the next step died:

```
Missing plugins
* github.com/hashicorp/ansible >= 1.1.3
Did you run packer init for this project ?
```

Only bites templates needing a plugin **not** baked into the image, which is why the null-builder fixture never caught it. Merged `packer-init` into `packer-action` so both run in one container.

Pointing `PACKER_PLUGIN_PATH` at the workspace was rejected as an alternative — verified that it *replaces* rather than extends the search path, hiding the baked-in vsphere/proxmox/qemu plugins (`packer plugins installed | grep -c vsphere` drops to 0).

Also: `ACTION=init` now always inits. Previously `ACTION=init RUN_INIT=false` reported success having done nothing.

## Verification

On a kind cluster against the **real private repo**:

| Stage | Result |
|---|---|
| `fetch-repository` via basic-auth | Succeeded |
| Subdirectory resolution | `packer/builds/ubuntu24-labul-vsphere-base-os` |
| `packer init` | installed `ansible` plugin |
| `packer validate` | proceeds past plugin resolution to template evaluation, stopping only at `Must set VAULT_TOKEN` (environmental — no vault on this cluster) |
| Null-builder `build` regression | Succeeded, `template-name=Null` |

## Known issues this does NOT fix

- **`packerTemplate: "."` (the default) fails on these repo dirs**, which hold two `.pkr.hcl` files defining the same locals. A single file must be named explicitly.
- **`templates/git-basicauth-secret.yaml` produces a non-working secret**: only an `insteadOf` rewrite requiring a trailing `/` after the repo name (never matches `<repo>.git`), and no credential helper, leaving `.git-credentials` inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TrLpL4ziRqUDZeTqeMyuF