### PR TITLE
chore: pin stage-time git-resolver self-refs to v0.9.0

### DIFF
--- a/kcl/ansible/kcl.mod
+++ b/kcl/ansible/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-tekton-pr"
 edition = "v0.11.2"
-version = "0.10.0"
+version = "0.11.0"
 
 [dependencies]
 tekton-pipelines = "1.0.0"

--- a/kcl/ansible/main.k
+++ b/kcl/ansible/main.k
@@ -39,7 +39,7 @@ _gitPath = _flat_params?.gitPath or _env?.gitPath or option("gitPath") or "pipel
 # from the content source above so pointing gitRepoUrl at an external playbook repo
 # no longer drags the pipeline definition with it.
 _pipelineRepoUrl = _flat_params?.pipelineRepoUrl or _env?.pipelineRepoUrl or option("pipelineRepoUrl") or "https://github.com/stuttgart-things/stage-time.git"
-_pipelineRevision = _flat_params?.pipelineRevision or _env?.pipelineRevision or option("pipelineRevision") or "v0.8.0"
+_pipelineRevision = _flat_params?.pipelineRevision or _env?.pipelineRevision or option("pipelineRevision") or "v0.9.0"
 
 # SOPS decrypt-after-git-clone (execute-ansible-playbooks pipeline only). Off by
 # default. When "true", the sops params are passed AND the sopsKeys workspace is

--- a/pipelines/build-image-buildah.yaml
+++ b/pipelines/build-image-buildah.yaml
@@ -88,7 +88,7 @@ spec:
           - name: url
             value: https://github.com/stuttgart-things/stage-time.git
           - name: revision
-            value: v0.8.0
+            value: v0.9.0
           - name: pathInRepo
             value: tasks/build-buildah.yaml
       runAfter:

--- a/pipelines/build-packer-template.yaml
+++ b/pipelines/build-packer-template.yaml
@@ -138,7 +138,7 @@ spec:
           - name: url
             value: https://github.com/stuttgart-things/stage-time.git
           - name: revision
-            value: v0.8.0
+            value: v0.9.0
           - name: pathInRepo
             value: tasks/execute-packer.yaml
       workspaces:

--- a/pipelines/execute-ansible-playbooks-from-collections.yaml
+++ b/pipelines/execute-ansible-playbooks-from-collections.yaml
@@ -100,7 +100,7 @@ spec:
           - name: url
             value: https://github.com/stuttgart-things/stage-time.git
           - name: revision
-            value: v0.8.0
+            value: v0.9.0
           - name: pathInRepo
             value: tasks/execute-ansible.yaml
 

--- a/pipelines/execute-ansible-playbooks.yaml
+++ b/pipelines/execute-ansible-playbooks.yaml
@@ -140,7 +140,7 @@ spec:
           - name: url
             value: https://github.com/stuttgart-things/stage-time.git
           - name: revision
-            value: v0.8.0
+            value: v0.9.0
           - name: pathInRepo
             value: tasks/execute-ansible.yaml
       workspaces:
@@ -229,7 +229,7 @@ spec:
           - name: url
             value: https://github.com/stuttgart-things/stage-time.git
           - name: revision
-            value: v0.8.0
+            value: v0.9.0
           - name: pathInRepo
             value: tasks/decrypt-sops.yaml
       workspaces:


### PR DESCRIPTION
`v0.8.0` still carries the **pre-#64** `execute-packer` task (separate `packer-init` step), so the plugin-persistence fix is not live until the pipelines resolve their tasks from a tag that contains it:

```
'packer-init' refs at v0.8.0: 2     <- old task, bug present
step on main:                0      <- fixed by #64
```

Bumps all six self-refs together, keeping the uniform-pin invariant from 7f2182a.

⚠️ **The `v0.9.0` tag must be cut on this PR's merge commit** or these pipelines cannot resolve their tasks at all. Same self-referential window as v0.8.0 — keep it short.

## Module versions

- `kcl-tekton-pr` 0.10.0 → **0.11.0** (changed `pipelineRevision` default)
- `kcl-tekton-pr-packer` stays **0.2.0** — its `pipelineRevision` defaults to `"main"`, so it needs no bump, but it has never been published and must be pushed

Both need a manual `kcl mod push` and a consumer pin bump in `crossplane-configurations` (`cicd/ansible-run`, `cicd/packer-build`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TrLpL4ziRqUDZeTqeMyuF