### PR TITLE
feat(packer): base image on sthings-ansible; add xorriso + vault secret template

### DIFF
--- a/images/packer/Dockerfile
+++ b/images/packer/Dockerfile
@@ -1,13 +1,20 @@
 # BASE
-FROM ghcr.io/stuttgart-things/sthings-alpine:3.11.14-alpine3.23
+# Built on sthings-ansible rather than sthings-alpine: the packer templates
+# this image builds use the `ansible` provisioner, which shells out to the
+# ansible-playbook BINARY (the packer ansible *plugin* is only a shim and does
+# not bring ansible with it). Their galaxy requirements pull in
+# community.hashi_vault, community.vmware, kubernetes.core and community.docker,
+# whose Python deps (hvac, PyVmomi, kubernetes, ...) are exactly the set
+# sthings-ansible already installs. Inheriting that stack avoids maintaining a
+# second copy of the pip list that would silently drift.
+FROM ghcr.io/stuttgart-things/sthings-ansible:14.0.0
 
 # METADATA INFORMATION
-LABEL version=1.15.1
+LABEL version=1.16.0
 LABEL maintainer="Patrick Hermann <patrick.hermann@sva.de>"
 
 # SOFTWARE
 ARG PACKER_VERSION=1.15.1
-ARG YQ_VERSION=4.53.2
 # Plugin versions baked into the image. They must satisfy the
 # `required_plugins` constraints in the templates this image builds; if a
 # template pins a newer plugin, `packer init` pulls it at run time (needs
@@ -20,16 +27,20 @@ ARG PACKER_PLUGIN_QEMU_VERSION=1.1.0
 ENV USER_ID=65532 \
     GROUP_ID=65532
 
-# RUNTIME PACKAGES (kept in the final image) + packer + yq.
-# openssh-client/git: templates that provision over SSH or fetch sources.
-# unzip: packer releases ship as a zip. ca-certificates: TLS to builders.
-RUN apk add --no-cache git curl wget tar bash unzip ca-certificates openssh-client \
+# RUNTIME PACKAGES + packer.
+# The base already provides git/curl/wget/tar/bash/ca-certificates/python3 and
+# yq, so only the packer-specific additions are installed here.
+# unzip: packer releases ship as a zip.
+# xorriso: REQUIRED at build time by any template using `cd_files` (the
+#   cloud-init user-data/meta-data ISO). packer accepts xorriso/mkisofs/hdiutil/
+#   oscdimg; without one the build dies with "could not find a supported CD ISO
+#   creation command". Note `packer validate` does NOT catch this.
+# openssh-client: templates that provision over SSH or fetch sources.
+RUN apk add --no-cache unzip xorriso openssh-client \
     && curl -fsSL "https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip" -o /tmp/packer.zip \
     && unzip /tmp/packer.zip -d /usr/bin \
     && chmod +x /usr/bin/packer \
-    && rm -f /tmp/packer.zip \
-    && curl -fsSL "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64" -o /usr/bin/yq \
-    && chmod +x /usr/bin/yq
+    && rm -f /tmp/packer.zip
 
 # PACKER PLUGINS — baked into the nonroot user's plugin dir so `packer init`
 # resolves them offline and runs don't re-download on every PipelineRun.

--- a/templates/packer-vault-secret.yaml
+++ b/templates/packer-vault-secret.yaml
@@ -1,0 +1,94 @@
+---
+# Vault credentials for the build-packer-template pipeline, delivered as an
+# InlineSopsSecret so the plaintext never has to leave the author's machine.
+#
+# The real packer templates resolve their hypervisor login through vault(),
+# e.g. vault("cloud/data/vsphere", "username"), so the pipeline cannot run
+# without these. The pipeline reads the keys individually and they are all
+# optional -- a missing key therefore fails at packer runtime, not at pod
+# start, which makes a typo here look like a Vault outage. Check the derived
+# Secret before blaming the lab.
+#
+# Two-step flow:
+#
+#   1. Write the plaintext Secret (the "stringData" block below) to a local
+#      file, then encrypt it to the cluster's age recipient:
+#
+#        sops --encrypt \
+#          --age <recipient> \
+#          --encrypted-regex '^(data|stringData)$' \
+#          vault-secret.yaml > vault-secret.enc.yaml
+#
+#      Encryption needs only the PUBLIC recipient key; the private half lives
+#      in the cluster (secret "sops-age-key", key "age.agekey"). Read the
+#      recipient off any InlineSopsSecret already applied to the target
+#      cluster rather than hardcoding one here -- it differs per cluster:
+#
+#        kubectl get inlinesopssecret -A \
+#          -o jsonpath='{.items[0].spec.encryptedYAML}' | grep recipient
+#
+#   2. Paste the ciphertext from step 1 under encryptedYAML below, indented.
+#
+# VAULT_TOKEN is REQUIRED. Packer's vault() template function builds a Vault
+# client from VAULT_ADDR and reads VAULT_TOKEN directly -- it never performs
+# an AppRole login. execute-packer injects VAULT_ROLE_ID / VAULT_SECRET_ID as
+# env vars, but no step consumes them and packer ignores them, so an
+# AppRole-only secret fails with:
+#
+#   Must set VAULT_TOKEN env var in order to use vault template function
+#
+# Supplying the AppRole pair as well is harmless and keeps the secret usable
+# by anything that does log in, but it is not a substitute for the token.
+# Since the token is long-lived here, scope it to a policy that can read only
+# the paths the templates need (e.g. cloud/data/vsphere) and rotate it.
+#
+# The plaintext to encrypt in step 1 looks like this -- drop the keys the lab
+# does not use, VAULT_NAMESPACE is Vault Enterprise / HCP only:
+#
+#   apiVersion: v1
+#   kind: Secret
+#   metadata:
+#     name: vault
+#     namespace: tekton-ci
+#   type: Opaque
+#   stringData:
+#     VAULT_ADDR: https://vault.example.com
+#     VAULT_TOKEN: <token>            # required, see above
+#     # VAULT_ROLE_ID: <role-id>      # inert for packer's vault()
+#     # VAULT_SECRET_ID: <secret-id>  # inert for packer's vault()
+#     # VAULT_NAMESPACE: <namespace>
+#
+# The secret name must match the pipeline's vaultSecretName param
+# (default: "vault"), and it must live in the namespace the PipelineRun runs
+# in.
+#
+# The operator reconciles this asynchronously, so confirm the derived Secret
+# exists before starting the PipelineRun:
+#
+#   kubectl get secret -n tekton-ci vault
+#
+# To remove: delete the InlineSopsSecret, not the derived Secret -- the CR
+# carries a finalizer and will recreate the Secret underneath you.
+apiVersion: sops.stuttgart-things.com/v1alpha2
+kind: InlineSopsSecret
+metadata:
+  name: vault
+  namespace: tekton-ci
+spec:
+  # Manifest: the decrypted payload is a complete Secret manifest (what the
+  # step-1 plaintext above is). The other mode, Mapping, expects a flat YAML
+  # plus a spec.data list mapping source keys to target Secret keys.
+  #
+  # The namespace inside the decrypted manifest is IGNORED -- the operator
+  # always uses this CR's namespace, so the CR must live where the
+  # PipelineRun runs.
+  mode: Manifest
+  decryption:
+    keyRef:
+      name: sops-age-key
+      key: age.agekey
+  # Paste the complete `sops --encrypt` output, indented to this column. The
+  # SOPS MAC covers the document, so it must be preserved byte for byte --
+  # reformatting or re-indenting the body breaks decryption.
+  encryptedYAML: |
+    # <-- sops output from step 1 goes here


### PR DESCRIPTION
## What

Rebases `images/packer/Dockerfile` from `sthings-alpine` onto `ghcr.io/stuttgart-things/sthings-ansible:14.0.0`, adds `xorriso`, and adds `templates/packer-vault-secret.yaml`.

## Why

The packer pipeline had never completed a real build (#65). Testing it against the LabUL vSphere lab surfaced three missing pieces in the image, each hidden behind the one before:

| # | Failure | Needs |
|---|---|---|
| 1 | `exec: "ansible-playbook": executable file not found in $PATH` | ansible |
| 2 | `could not find a supported CD ISO creation command` | `xorriso` |
| 3 | `community.hashi_vault` lookup: `Failed to import the required Python library (hvac)` | `hvac` |

Worth noting for future debugging:

- `packer init` installing the ansible **plugin** says nothing about the ansible **binary** — the plugin is only a shim that shells out to `ansible-playbook`.
- Failure 2 comes from `cd_files` (the cloud-init ISO) and **`packer validate` does not catch it**. A validate-only test run passes; the build then fails.

## Why this base image

The templates' `requirements.yaml` pulls in `community.hashi_vault`, `community.vmware`, `kubernetes.core` and `community.docker` — whose Python dependencies (`hvac`, `PyVmomi`, `kubernetes`, `docker`) are exactly the set `images/ansible/Dockerfile` already installs. Adding them here one at a time would be whack-a-mole; copying the pip block would leave two lists to drift apart.

Trade-off: image grows 195 MB → 365 MB, and the packer image now tracks the ansible image's release cadence.

Note the inherited baked collections are effectively dead weight — the template sets `galaxy_force_install = true` and overwrites them. It is the Python libraries we are actually inheriting. A shared base carrying the pip stack without collections would be leaner, but that is a bigger refactor than this fixes.

## Verification

With this image, the pipeline completed a **real vSphere build** end to end:

```
template-name = ubuntu24-base-20260719-0756
Build 'vsphere-iso.ubuntu24_base' finished after 18 minutes 58 seconds.
==> Converting virtual machine to template...
```

19m46s total, against a 2h timeout. The machine-readable artifact-name parse returned the correct VM name — previously exercised only against the null builder's `id=Null`, and flagged in #65 as the highest-risk untested path.

Caveat: the name was verified against packer's own artifact output, not independently against vCenter — its REST API was returning 503 during testing.

That run also required an ESXi host fix in the template repo (`stuttgart-things`, host `.54` → `.53`), which is not part of this PR.

## Not in this PR, deliberately

`packerWorkingImage` still defaults to `sthings-packer:1.15.1`. The 1.16.0 image does not exist until this merges and the publish workflow runs, so bumping the default here would point the pipeline at a missing tag. That bump plus a `v0.10.0` tag should be a follow-up, and the build should then be re-run **on pure defaults** to prove the published artifacts rather than a locally-built image.

Refs #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TrLpL4ziRqUDZeTqeMyuF
