### PR TITLE
fix(packer): correct LABEL version to match the published tag

### DIFF
--- a/images/packer/Dockerfile
+++ b/images/packer/Dockerfile
@@ -10,7 +10,14 @@
 FROM ghcr.io/stuttgart-things/sthings-ansible:14.0.0
 
 # METADATA INFORMATION
-LABEL version=1.16.0
+# NOTE: this LABEL is metadata only -- it does NOT drive the published tag.
+# .github/workflows/docker-build-packer.yaml resolves the tag from
+# ARG PACKER_VERSION below, so the image tag tracks the packer BINARY version.
+# Keep the two in sync, or the label will name a version that was never
+# published (as 1.16.0 did). A consequence worth knowing: an image-content
+# change that leaves PACKER_VERSION alone republishes the SAME tag with
+# different contents -- consumers pinned to it silently get a new image.
+LABEL version=1.15.1
 LABEL maintainer="Patrick Hermann <patrick.hermann@sva.de>"
 
 # SOFTWARE


### PR DESCRIPTION
`LABEL version` was bumped to `1.16.0` in #67 on the assumption that it drove the published image tag. It does not.

`.github/workflows/docker-build-packer.yaml` resolves the tag from `ARG PACKER_VERSION`:

```
version=$(grep -oP '^ARG PACKER_VERSION=\K.*' images/packer/Dockerfile)
```

So merging #67 republished `ghcr.io/stuttgart-things/sthings-packer:1.15.1` (and `:latest`) in place with entirely new contents — alpine-based 195 MB → ansible-based 383 MB — and **1.16.0 was never published**. Packer 1.16.0 does not exist upstream either (latest is v1.15.4), so the tag cannot simply be bumped to match the label.

This sets the label back to `1.15.1` and documents that it is metadata only, along with the consequence of tag==packer-version: an image-content change that leaves `PACKER_VERSION` alone republishes the same tag, and consumers pinned to it silently get a different image.

**No functional change** — the Dockerfile build is untouched, so this does not alter the published image.

### Follow-up, not in this PR

Decoupling the image version from the packer version (e.g. a separate `IMAGE_VERSION` the workflow tags from) is the real fix. Bumping `PACKER_VERSION` to `1.15.4` would also avoid the overwrite and pick up the update packer currently warns about, but that changes the packer binary under a pipeline that was only just validated end to end, so it deserves its own change and a re-run. Tracked in #65.

### Context

The published `:1.15.1` was verified to carry a full defaults-only vSphere build on 2026-07-20 (`ubuntu24-base-20260720-1118`, 21m57s) — see #65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TrLpL4ziRqUDZeTqeMyuF