### PR TITLE
feat(kcl/packer): pin pipelineRevision, add hypervisor + caCerts workspace

### DIFF
--- a/kcl/packer/CLAUDE.md
+++ b/kcl/packer/CLAUDE.md
@@ -25,8 +25,26 @@ a DIFFERENT repo than the pipeline:
 - `gitRepoUrl`/`gitRevision`/`gitWorkspaceSubdirectory` → pipeline PARAMS that
   tell the git-clone task which `*.pkr.hcl` to check out
   (`stuttgart-things/stuttgart-things`, `packer/builds/<os>-<lab>-vsphere-<prov>/`).
-- `osVersion`+`lab`+`provisioning` compose `gitWorkspaceSubdirectory` when it
-  isn't set explicitly (mirrors the `dispatch-packer-build` action's BUILD_DIR).
+- `osVersion`+`lab`+`hypervisor`+`provisioning` compose
+  `gitWorkspaceSubdirectory` when it isn't set explicitly (mirrors the
+  `dispatch-packer-build` action's BUILD_DIR). `hypervisor` defaults to
+  `vsphere`; before 0.3.0 it was hardcoded, leaving the `*-proxmox-*` build
+  dirs reachable only via an explicit `gitWorkspaceSubdirectory`.
+
+## Optional workspaces
+Two workspaces are emitted only when their name field is non-empty, so the
+pipeline's optional workspaces stay unbound by default:
+- `gitBasicAuthSecretName` → `basicAuth` (required to clone the private
+  template repo over https).
+- `caCertsConfigMapName` → `caCerts` (required when Vault is behind a private
+  CA, else `x509: certificate signed by unknown authority`). Added in 0.4.0 —
+  before that the module emitted no `caCerts` workspace at all, so the
+  Crossplane XR path could not build against the LabUL Vault even though the
+  pipeline supported it.
+
+`pipelineRevision` defaults to a PINNED tag, not `main`: the git resolver
+fetches the pipeline definition at render time, so an unpinned default
+silently changes what runs whenever stage-time's main moves.
 
 ## Invocation contract (two modes)
 Same as `kcl-tekton-pr`: Composition mode (`params.oxr.spec` + `ctx` env +
@@ -47,8 +65,14 @@ Always render before bumping the version — `kcl` is the source of truth for
 whether the module is valid.
 
 ## Consumer
-`stuttgart-things/crossplane-configurations` → `cicd/packer-build` (planned):
+`stuttgart-things/crossplane-configurations` → `cicd/packer-build`:
 the Composition's `render-pipelinerun` step pins a specific tag of this module.
 The pinned version MUST be published or the Configuration's verify CI fails
 with `failed to resolve <v>: ...kcl-tekton-pr-packer:<v>: not found`. Order:
 bump `kcl.mod` → `kcl mod push` → bump the pin in the consumer.
+
+**The ghcr package is PRIVATE** (unlike the ansible module's `kcl-tekton-pr`,
+which is public). function-kcl pulls anonymously, so any Composition pinning
+this module fails to render with `401 unauthorized` until the package
+visibility is flipped to public in the GHCR UI — there is no REST endpoint for
+it. This is why `cicd/packer-build` cannot render end to end yet.

--- a/kcl/packer/kcl.mod
+++ b/kcl/packer/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-tekton-pr-packer"
 edition = "v0.11.2"
-version = "0.2.0"
+version = "0.4.0"
 
 [dependencies]
 tekton-pipelines = "1.0.0"

--- a/kcl/packer/main.k
+++ b/kcl/packer/main.k
@@ -32,7 +32,11 @@ _pipelineRunName = _flat_params?.pipelineRunName or option("pipelineRunName") or
 # This is the stage-time repo and is DISTINCT from the template source repo
 # below — packer templates live elsewhere (stuttgart-things/stuttgart-things).
 _pipelineRepoUrl = _flat_params?.pipelineRepoUrl or _env?.pipelineRepoUrl or option("pipelineRepoUrl") or "https://github.com/stuttgart-things/stage-time.git"
-_pipelineRevision = _flat_params?.pipelineRevision or _env?.pipelineRevision or option("pipelineRevision") or "main"
+# Pinned to a released tag, NOT "main": the git resolver fetches the pipeline
+# definition at render time, so an unpinned default silently changes what runs
+# whenever stage-time's main moves. Matches kcl/ansible. Bump alongside the
+# pipeline; v0.9.0 is the tag every validated packer run has used.
+_pipelineRevision = _flat_params?.pipelineRevision or _env?.pipelineRevision or option("pipelineRevision") or "v0.9.0"
 _pipelinePath = _flat_params?.pipelinePath or _env?.pipelinePath or option("pipelinePath") or "pipelines/build-packer-template.yaml"
 
 # --- Template SOURCE repo (the .pkr.hcl templates the pipeline checks out) ---
@@ -45,6 +49,14 @@ _gitRevision = _flat_params?.gitRevision or option("gitRevision") or "main"
 # authenticated by the sshCredentials workspace. Empty = workspace unbound.
 _gitBasicAuthSecretName = _flat_params?.gitBasicAuthSecretName or _env?.gitBasicAuthSecretName or option("gitBasicAuthSecretName") or ""
 
+# Name of a ConfigMap holding PEM CA certificates (*.crt / *.pem), mounted as
+# the pipeline's optional `caCerts` workspace. REQUIRED when Vault (or any
+# endpoint packer talks to) is behind a private CA, otherwise the run dies with
+#   x509: certificate signed by unknown authority
+# The CA is downloadable unauthenticated from Vault itself at /v1/pki/ca/pem.
+# Empty = workspace unbound (fine for publicly-trusted endpoints).
+_caCertsConfigMapName = _flat_params?.caCertsConfigMapName or _env?.caCertsConfigMapName or option("caCertsConfigMapName") or ""
+
 # Higher-level build selectors, mirroring the dispatch-packer-build action's
 # BUILD_DIR = packer/builds/<os>-<lab>-vsphere-<provisioning>. When
 # gitWorkspaceSubdirectory is not given explicitly but os/lab/provisioning are,
@@ -52,7 +64,11 @@ _gitBasicAuthSecretName = _flat_params?.gitBasicAuthSecretName or _env?.gitBasic
 _osVersion = _flat_params?.osVersion or option("osVersion") or ""
 _lab = _flat_params?.lab or _env?.lab or option("lab") or ""
 _provisioning = _flat_params?.provisioning or option("provisioning") or ""
-_computedSubdir = "packer/builds/${_osVersion}-${_lab}-vsphere-${_provisioning}" if (_osVersion and _lab and _provisioning) else ""
+# Hypervisor segment. Was hardcoded to "vsphere", which left the *-proxmox-*
+# build dirs reachable only by passing gitWorkspaceSubdirectory explicitly.
+# Defaults to vsphere so existing callers are unaffected.
+_hypervisor = _flat_params?.hypervisor or _env?.hypervisor or option("hypervisor") or "vsphere"
+_computedSubdir = "packer/builds/${_osVersion}-${_lab}-${_hypervisor}-${_provisioning}" if (_osVersion and _lab and _provisioning) else ""
 _gitWorkspaceSubdirectory = _flat_params?.gitWorkspaceSubdirectory or option("gitWorkspaceSubdirectory") or _computedSubdir or ""
 
 # --- Packer run configuration ---
@@ -78,6 +94,7 @@ assert _gitRepoUrl.startswith("https://github.com/"), "gitRepoUrl must be a vali
 assert _pipelineRepoUrl.startswith("https://github.com/"), "pipelineRepoUrl must be a valid GitHub HTTPS URL"
 assert len(_gitRevision) > 0, "gitRevision cannot be empty"
 assert _packerAction in ["init", "validate", "build"], "packerAction must be init, validate or build"
+assert _hypervisor in ["vsphere", "proxmox", "qemu"], "hypervisor must be vsphere, proxmox or qemu"
 assert _storageSize.endswith("Mi") or _storageSize.endswith("Gi"), "storageSize must end with 'Mi' or 'Gi'"
 assert _storageAccessModes in ["ReadWriteOnce", "ReadWriteMany", "ReadOnlyMany"], "storageAccessModes must be ReadWriteOnce, ReadWriteMany, or ReadOnlyMany"
 
@@ -129,6 +146,15 @@ _basicAuthWorkspaces = [
     }
 ] if _gitBasicAuthSecretName else []
 
+# Optional CA-bundle workspace, same conditional pattern as basicAuth so the
+# pipeline's optional `caCerts` workspace stays unbound by default.
+_caCertsWorkspaces = [
+    {
+        name = "caCerts"
+        configMap = {name = _caCertsConfigMapName}
+    }
+] if _caCertsConfigMapName else []
+
 # Pipeline params — keys must match build-packer-template.yaml's param names.
 _pipeline_params_override = {
     packerAction = _packerAction
@@ -164,7 +190,7 @@ _pipelineRun = tekton.PipelineRun {
         params = [{name = k, value = v} for k, v in _pipeline_params_override]
         taskRunTemplate = vars._task_run_template
         timeouts = vars._timeouts
-        workspaces = [_workspace_config_override] + _basicAuthWorkspaces
+        workspaces = [_workspace_config_override] + _basicAuthWorkspaces + _caCertsWorkspaces
     }
 }
 

--- a/kcl/packer/main.k
+++ b/kcl/packer/main.k
@@ -32,6 +32,7 @@ _pipelineRunName = _flat_params?.pipelineRunName or option("pipelineRunName") or
 # This is the stage-time repo and is DISTINCT from the template source repo
 # below — packer templates live elsewhere (stuttgart-things/stuttgart-things).
 _pipelineRepoUrl = _flat_params?.pipelineRepoUrl or _env?.pipelineRepoUrl or option("pipelineRepoUrl") or "https://github.com/stuttgart-things/stage-time.git"
+
 # Pinned to a released tag, NOT "main": the git resolver fetches the pipeline
 # definition at render time, so an unpinned default silently changes what runs
 # whenever stage-time's main moves. Matches kcl/ansible. Bump alongside the
@@ -64,6 +65,7 @@ _caCertsConfigMapName = _flat_params?.caCertsConfigMapName or _env?.caCertsConfi
 _osVersion = _flat_params?.osVersion or option("osVersion") or ""
 _lab = _flat_params?.lab or _env?.lab or option("lab") or ""
 _provisioning = _flat_params?.provisioning or option("provisioning") or ""
+
 # Hypervisor segment. Was hardcoded to "vsphere", which left the *-proxmox-*
 # build dirs reachable only by passing gitWorkspaceSubdirectory explicitly.
 # Defaults to vsphere so existing callers are unaffected.


### PR DESCRIPTION
Three fixes to `kcl-tekton-pr-packer`, all surfaced while building the `cicd/packer-build` Crossplane Configuration that consumes it. Published as **0.4.0** (0.2.0 and 0.3.0 untouched).

### 1. `pipelineRevision` was unpinned (#65)

It defaulted to `main`. The git resolver fetches the pipeline definition at render time, so an unpinned default silently changes what runs whenever stage-time's main moves. Now defaults to `v0.9.0` — matching `kcl/ansible`, and the tag every validated packer run has used.

### 2. Hypervisor was hardcoded (#65)

The composed build directory always said `vsphere`, leaving the three `*-proxmox-*` build dirs reachable only by passing `gitWorkspaceSubdirectory` explicitly. Now a `hypervisor` field defaulting to `vsphere` (so existing callers are unaffected) with an enum assert.

```
-D hypervisor=proxmox  ->  packer/builds/ubuntu24-labul-proxmox-base-os
(default)              ->  packer/builds/ubuntu24-labul-vsphere-base-os
```

### 3. No `caCerts` workspace at all — found by testing

The module emitted no `caCerts` workspace, though the pipeline accepts one (`optional: true`). **Every validated real build required it**, because the LabUL Vault sits behind a private CA — so the Crossplane XR path would have failed with `x509: certificate signed by unknown authority` on its first real run, reproducing a blocker that took a while to diagnose the first time.

`caCertsConfigMapName` now emits it, using the same conditional pattern as `gitBasicAuthSecretName` so it stays unbound by default.

### Verification

Rendered in composition mode with the exact XR spec + EnvironmentConfig the new Configuration produces. Output matches the PipelineRun that built `ubuntu24-base-20260720-1118`: same subdirectory, pinned resolver, and all three workspaces (`shared-workspace`, `basicAuth`, `caCerts`).

### Note for reviewers

`ghcr.io/stuttgart-things/kcl-tekton-pr-packer` is a **private** package, unlike the public `kcl-tekton-pr`. `function-kcl` pulls anonymously, so the consuming Configuration cannot render until visibility is flipped to public in the GHCR UI (there is no REST endpoint). Documented in the module's CLAUDE.md.

Consumer PR: stuttgart-things/crossplane-configurations `cicd/packer-build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TrLpL4ziRqUDZeTqeMyuF