### PR TITLE
fix(templates): make git-basicauth-secret actually authenticate

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -55,7 +55,7 @@ tasks:
         machineshop render \
         --source local \
         --template templates/git-basicauth-secret.yaml \
-        --values "gitServer=github.com, user=user1, token=bla, repo=https://github.com/stuttgart-things/, name=patrick hermann, email=patrick@test.com, scm=github"
+        --values "name=packer-git-basicauth, gitServer=github.com, user=user1, token=bla, userName=patrick hermann, email=patrick@test.com"
 
   vcluster:
     desc: Create/Destory vcluster

--- a/templates/git-basicauth-secret.yaml
+++ b/templates/git-basicauth-secret.yaml
@@ -26,8 +26,9 @@
 #
 # SCOPE: this credential matches every repo on {{ .gitServer }}. Git matches
 # stored credentials by host, and by path prefix when one is given -- so
-# append a path (https://user:token@github.com/stuttgart-things) if the token
-# should not cover the whole host.
+# append an org/repo path to the .git-credentials line below (i.e. end it
+# with /stuttgart-things instead of at the host) if the token should not
+# cover the whole host.
 kind: Secret
 apiVersion: v1
 metadata:

--- a/templates/git-basicauth-secret.yaml
+++ b/templates/git-basicauth-secret.yaml
@@ -1,15 +1,44 @@
 ---
+# Basic-auth Secret for cloning a PRIVATE git repo over https.
+#
+# Mounted as the `basicAuth` workspace by the packer/ansible pipelines, which
+# point HOME at the workspace so git picks up both files below.
+#
+# Render with machineshop, e.g.:
+#   machineshop render --source local \
+#     --template templates/git-basicauth-secret.yaml \
+#     --values "name=packer-git-basicauth, gitServer=github.com, \
+#               user=<user>, token=<pat>, \
+#               userName=<full name>, email=<mail>"
+# (see `task render-scm-secret`)
+#
+# WHY IT LOOKS LIKE THIS -- the previous version produced a Secret that never
+# authenticated anything, and every real run had to hand-roll a replacement:
+#
+#   * No `[credential] helper` was configured, so git never consulted
+#     .git-credentials at all. That helper line is what loads the file.
+#   * The url/insteadOf rewrite had a TRAILING SLASH on both sides
+#     (`https://github.com/<repo>/`), so it never matched a real remote such
+#     as `https://github.com/stuttgart-things/stuttgart-things.git`.
+#
+# The rewrite is dropped entirely: `helper = store` plus a host-scoped
+# credential line is sufficient, and has far fewer ways to be subtly wrong.
+#
+# SCOPE: this credential matches every repo on {{ .gitServer }}. Git matches
+# stored credentials by host, and by path prefix when one is given -- so
+# append a path (https://user:token@github.com/stuttgart-things) if the token
+# should not cover the whole host.
 kind: Secret
 apiVersion: v1
 metadata:
-  name: basic-{{ .scm }}-auth
+  name: {{ .name }}
 type: Opaque
 stringData:
   .gitconfig: |
-    [url "https://{{ .user }}:{{ .token }}@{{ .gitServer }}/{{ .repo }}/"]
-        insteadOf = https://{{ .gitServer }}/{{ .repo }}/
+    [credential]
+        helper = store
     [user]
-        name = {{ .name }}
+        name = {{ .userName }}
         email = {{ .email }}
   .git-credentials: |
-    https://{{ .user }}:{{ .token }}@{{ .gitServer }}/{{ .repo }}
+    https://{{ .user }}:{{ .token }}@{{ .gitServer }}


### PR DESCRIPTION
The rendered Secret never authenticated anything, so every real packer run had to hand-roll a replacement. This is issue #65, bug 2.

### Two independent defects

```gitconfig
[url "https://<user>:<token>@github.com/<repo>/"]
    insteadOf = https://github.com/<repo>/
```

1. **No `[credential] helper`** was configured, so git never consulted `.git-credentials` at all. That line is what loads the file.
2. **The url/insteadOf rewrite had a trailing slash on both sides**, so it never matched a real remote such as `https://github.com/stuttgart-things/stuttgart-things.git`.

Either one alone breaks it.

### Fix

Drops the rewrite entirely — `helper = store` plus a host-scoped credential line is sufficient and has far fewer ways to be subtly wrong:

```gitconfig
[credential]
    helper = store
```
```
https://<user>:<token>@github.com
```

Also renames the templated fields so the Secret name is settable — the packer EnvironmentConfig expects `packer-git-basicauth`, not `basic-<scm>-auth` — and so `name` no longer means both the Secret name and the git user's name.

### Verification

`git credential fill` against a temp `HOME` built from the rendered Secret:

| template | result |
|---|---|
| **new** | returns `username=` + `password=` ✅ |
| **old** | `Missing or invalid credentials`, then falls through to an interactive helper |

That fallback is the actual failure mode: in a pipeline container there is no interactive credential helper, so the clone just fails.

`task render-scm-secret` is updated to the new value names (its old `--values` passed `repo=https://github.com/stuttgart-things/` into a `{{ .gitServer }}/{{ .repo }}` slot, which produced a doubled URL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TrLpL4ziRqUDZeTqeMyuF