### PR TITLE
feat(packer): decouple image version, add govc, and promote templates keeping one generation

### DIFF
--- a/.github/workflows/docker-build-packer.yaml
+++ b/.github/workflows/docker-build-packer.yaml
@@ -99,12 +99,42 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Resolve image version from Dockerfile
+      # Two independent versions, both read from the Dockerfile so there is one
+      # source of truth. IMAGE_VERSION names the image; PACKER_VERSION only
+      # names the binary inside it and is published as a FLOATING alias.
+      - name: Resolve versions from Dockerfile
         id: meta
         run: |
-          version=$(grep -oP '^ARG PACKER_VERSION=\K.*' images/packer/Dockerfile)
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
-          echo "Resolved version: ${version}"
+          set -euo pipefail
+          image_version=$(grep -oP '^ARG IMAGE_VERSION=\K.*' images/packer/Dockerfile)
+          packer_version=$(grep -oP '^ARG PACKER_VERSION=\K.*' images/packer/Dockerfile)
+          # Fail loudly rather than publishing ":" if an ARG is renamed away.
+          [ -n "${image_version}" ] || { echo "::error::ARG IMAGE_VERSION not found in images/packer/Dockerfile"; exit 1; }
+          [ -n "${packer_version}" ] || { echo "::error::ARG PACKER_VERSION not found in images/packer/Dockerfile"; exit 1; }
+          echo "version=${image_version}" >> "$GITHUB_OUTPUT"
+          echo "packer_version=${packer_version}" >> "$GITHUB_OUTPUT"
+          echo "image: ${image_version} / packer: ${packer_version}"
+
+      # An image version must be published exactly once. Overwriting it would
+      # reintroduce the very problem this split fixes, so refuse rather than
+      # silently mutate a tag someone has pinned. Bump ARG IMAGE_VERSION.
+      #
+      # The login is separate from the lookup on purpose: an auth failure and a
+      # missing tag both make `docker manifest inspect` exit non-zero, so
+      # treating "inspect failed" as "tag is free" would let a broken token
+      # wave an overwrite through. Log in first and fail hard if that fails.
+      - name: Refuse to overwrite an existing image version
+        env:
+          TAG: ${{ steps.meta.outputs.version }}
+        run: |
+          set -euo pipefail
+          printf '%s' "${REGISTRY_PASSWORD}" \
+            | docker login "${REGISTRY}" -u "${REGISTRY_USERNAME}" --password-stdin
+          if docker manifest inspect "${REGISTRY}/${IMAGE}:${TAG}" >/dev/null 2>&1; then
+            echo "::error::${REGISTRY}/${IMAGE}:${TAG} already exists. Bump ARG IMAGE_VERSION in images/packer/Dockerfile."
+            exit 1
+          fi
+          echo "${TAG} is free"
 
       - name: Dagger Build and Push (ghcr :sha)
         uses: dagger/dagger-for-github@v8.4.1
@@ -140,6 +170,9 @@ jobs:
 
       # crane copy = re-tag by digest (no rebuild). Source is the private ghcr
       # :sha just pushed, so source creds are passed alongside target creds.
+      #
+      # :<IMAGE_VERSION> is the tag to pin. The step above guarantees it did
+      # not already exist, so it is immutable in practice.
       - name: Crane re-tag :sha → :version
         uses: dagger/dagger-for-github@v8.4.1
         with:
@@ -149,6 +182,27 @@ jobs:
             copy
             --source ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ github.sha }}
             --target ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ steps.meta.outputs.version }}
+            --source-registry ${{ env.REGISTRY }}
+            --source-username ${{ github.actor }}
+            --source-password env:REGISTRY_PASSWORD
+            --target-registry ${{ env.REGISTRY }}
+            --target-username ${{ github.actor }}
+            --target-password env:REGISTRY_PASSWORD
+          cloud-token: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+
+      # A FLOATING alias: "whatever image currently carries this packer
+      # binary". Prefixed so it can never be mistaken for an image version --
+      # a bare `:1.15.1` used to mean both, which is how a pinned tag came to
+      # change underneath its consumers. Nothing should pin this.
+      - name: Crane re-tag :sha → :packer-<version>
+        uses: dagger/dagger-for-github@v8.4.1
+        with:
+          version: v0.20.3
+          module: github.com/stuttgart-things/dagger/crane@v0.91.0
+          call: >-
+            copy
+            --source ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ github.sha }}
+            --target ${{ env.REGISTRY }}/${{ env.IMAGE }}:packer-${{ steps.meta.outputs.packer_version }}
             --source-registry ${{ env.REGISTRY }}
             --source-username ${{ github.actor }}
             --source-password env:REGISTRY_PASSWORD
@@ -181,6 +235,13 @@ jobs:
             echo ""
             echo "Built once as \`:${{ github.sha }}\`, crane-promoted to:"
             echo ""
-            echo "- \`${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ steps.meta.outputs.version }}\`"
-            echo "- \`${{ env.REGISTRY }}/${{ env.IMAGE }}:latest\`"
+            echo "| Tag | Meaning | Pin it? |"
+            echo "|---|---|---|"
+            echo "| \`:${{ steps.meta.outputs.version }}\` | this image, published once | **yes** |"
+            echo "| \`:packer-${{ steps.meta.outputs.packer_version }}\` | floating: latest image carrying packer ${{ steps.meta.outputs.packer_version }} | no |"
+            echo "| \`:latest\` | floating | no |"
+            echo ""
+            echo "Tags below \`2.0.0\` (\`:1.15.1\` and earlier) were named after the"
+            echo "packer binary and are no longer written to — they now keep whatever"
+            echo "content they last had."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/images/packer/Dockerfile
+++ b/images/packer/Dockerfile
@@ -9,19 +9,37 @@
 # second copy of the pip list that would silently drift.
 FROM ghcr.io/stuttgart-things/sthings-ansible:14.0.0
 
+# VERSIONS
+#
+# IMAGE_VERSION is the version of THIS IMAGE and drives the published tag.
+# PACKER_VERSION is the version of the packer BINARY inside it. They are
+# independent on purpose: adding a tool (govc), rebasing, or patching a CVE
+# changes the image without changing packer.
+#
+# Until 2026-07 the published tag came from PACKER_VERSION, which meant any
+# image-content change at the same packer version REPUBLISHED THE SAME TAG
+# with different contents -- anyone pinned to it silently got a different
+# image, and there was no tag that could express "the image changed". It also
+# made LABEL version drift from reality (a 1.15.1 label sat on an image
+# claiming 1.16.0, a version that was never published at all).
+#
+# Bump IMAGE_VERSION on EVERY change to this directory. Bump PACKER_VERSION
+# only when moving the packer binary; that bumps IMAGE_VERSION too.
+ARG IMAGE_VERSION=2.0.0
+ARG PACKER_VERSION=1.15.1
+
 # METADATA INFORMATION
-# NOTE: this LABEL is metadata only -- it does NOT drive the published tag.
-# .github/workflows/docker-build-packer.yaml resolves the tag from
-# ARG PACKER_VERSION below, so the image tag tracks the packer BINARY version.
-# Keep the two in sync, or the label will name a version that was never
-# published (as 1.16.0 did). A consequence worth knowing: an image-content
-# change that leaves PACKER_VERSION alone republishes the SAME tag with
-# different contents -- consumers pinned to it silently get a new image.
-LABEL version=1.15.1
+# Both labels are interpolated from the ARGs above, so they cannot drift from
+# what was actually built -- the previous hand-maintained LABEL did.
+LABEL version=${IMAGE_VERSION}
+LABEL packer.version=${PACKER_VERSION}
 LABEL maintainer="Patrick Hermann <patrick.hermann@sva.de>"
 
 # SOFTWARE
-ARG PACKER_VERSION=1.15.1
+# govc drives the vCenter side of the pipeline (template rename/move/delete on
+# promotion). It lives here rather than in a separate image so a promote step
+# inherits the same Vault wiring the build already has.
+ARG GOVC_VERSION=0.53.0
 # Plugin versions baked into the image. They must satisfy the
 # `required_plugins` constraints in the templates this image builds; if a
 # template pins a newer plugin, `packer init` pulls it at run time (needs
@@ -47,7 +65,11 @@ RUN apk add --no-cache unzip xorriso openssh-client \
     && curl -fsSL "https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip" -o /tmp/packer.zip \
     && unzip /tmp/packer.zip -d /usr/bin \
     && chmod +x /usr/bin/packer \
-    && rm -f /tmp/packer.zip
+    && rm -f /tmp/packer.zip \
+    && curl -fsSL "https://github.com/vmware/govmomi/releases/download/v${GOVC_VERSION}/govc_Linux_x86_64.tar.gz" -o /tmp/govc.tar.gz \
+    && tar -xzf /tmp/govc.tar.gz -C /usr/bin govc \
+    && chmod +x /usr/bin/govc \
+    && rm -f /tmp/govc.tar.gz
 
 # PACKER PLUGINS — baked into the nonroot user's plugin dir so `packer init`
 # resolves them offline and runs don't re-download on every PipelineRun.

--- a/pipelines/promote-packer-template.yaml
+++ b/pipelines/promote-packer-template.yaml
@@ -1,0 +1,117 @@
+---
+# Promote a freshly built packer template to the golden image.
+#
+# Deliberately a SEPARATE pipeline from build-packer-template rather than a
+# task appended to it: promotion must be gated on the template having been
+# tested, and a build pipeline has no way to know that. The gate lives one
+# layer up (the PackerRelease XR in crossplane-configurations), which creates
+# this PipelineRun only once its smoke test has passed.
+#
+# Everything this pipeline needs it takes as parameters -- there is no git
+# clone, no workspace to populate. The only workspace is the optional CA
+# bundle, needed because the LabUL Vault holding the vCenter credentials sits
+# behind a private CA.
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: promote-packer-template
+spec:
+  workspaces:
+    - name: caCerts
+      optional: true
+  params:
+    - name: templateName
+      type: string
+      description: >-
+        the freshly built template to promote, e.g.
+        "ubuntu24-base-20260721-1131" -- the `template-name` result emitted by
+        build-packer-template
+    - name: goldenName
+      type: string
+      description: name the golden image is published under, e.g. "sthings-u24"
+    - name: buildFolder
+      type: string
+      description: inventory path packer builds into, e.g. "/LabUL/vm/stuttgart-things/packer"
+    - name: goldenFolder
+      type: string
+      description: inventory path golden images live in, e.g. "/LabUL/vm/stuttgart-things/vm-templates"
+    - name: previousSuffix
+      type: string
+      default: "-previous"
+      description: >-
+        suffix for the retained previous generation. Exactly one is kept, so a
+        bad golden image is one rename away from being rolled back.
+    - name: datacenter
+      type: string
+      default: ""
+      description: vCenter datacenter, e.g. "/LabUL"
+    - name: insecureSkipVerify
+      type: string
+      default: "true"
+      description: skip vCenter TLS verification (self-signed certs in the labs)
+    - name: vaultSecretPath
+      type: string
+      default: "cloud/data/vsphere"
+      description: Vault KV v2 path holding the vCenter credentials
+    - name: vaultSecretName
+      type: string
+      default: "vault"
+      description: name of the Secret carrying VAULT_ADDR / VAULT_TOKEN
+    - name: userHome
+      type: string
+      default: "/home/nonroot"
+    - name: workingImage
+      type: string
+      default: "ghcr.io/stuttgart-things/sthings-packer:2.0.0"
+      description: must be >= 2.0.0 -- govc was added in that image version
+  results:
+    - name: promoted-template
+      description: inventory path the golden image now lives at
+      value: $(tasks.promote.results.promoted-template)
+    - name: previous-template
+      description: >-
+        inventory path the superseded golden image was renamed to, or empty on
+        a first promotion. Roll back by renaming it back to goldenName.
+      value: $(tasks.promote.results.previous-template)
+  tasks:
+    - name: promote
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/stuttgart-things/stage-time.git
+          # Pinned tag, not "main": the git resolver fetches at render time, so
+          # an unpinned default silently changes what runs. Bump alongside the
+          # task. Must be a tag that CONTAINS tasks/execute-govc.yaml.
+          - name: revision
+            value: v0.10.0
+          - name: pathInRepo
+            value: tasks/execute-govc.yaml
+      workspaces:
+        - name: ca-certs
+          workspace: caCerts
+      params:
+        - name: ACTION
+          value: promote
+        - name: TEMPLATE_NAME
+          value: $(params.templateName)
+        - name: GOLDEN_NAME
+          value: $(params.goldenName)
+        - name: BUILD_FOLDER
+          value: $(params.buildFolder)
+        - name: GOLDEN_FOLDER
+          value: $(params.goldenFolder)
+        - name: PREVIOUS_SUFFIX
+          value: $(params.previousSuffix)
+        - name: DATACENTER
+          value: $(params.datacenter)
+        - name: INSECURE_SKIP_VERIFY
+          value: $(params.insecureSkipVerify)
+        - name: VAULT_SECRET_PATH
+          value: $(params.vaultSecretPath)
+        - name: vault-secret-name
+          value: $(params.vaultSecretName)
+        - name: USER_HOME
+          value: $(params.userHome)
+        - name: WORKING_IMAGE
+          value: $(params.workingImage)

--- a/tasks/execute-govc.yaml
+++ b/tasks/execute-govc.yaml
@@ -1,0 +1,422 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: execute-govc
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/categories: "infrastructure"
+    tekton.dev/pipelines.minVersion: "0.17.0"
+    tekton.dev/platforms: "linux/amd64,linux/arm64"
+    tekton.dev/tags: "vsphere,vcenter,govc,image-build"
+spec:
+  description: >-
+    vCenter object operations with govc: promote a freshly built packer
+    template to the golden image (keeping one previous generation), or run the
+    rename/move/delete primitives on their own.
+  workspaces:
+    - name: ca-certs
+      description: >-
+        optional workspace with private CA certificates (*.crt / *.pem) that
+        are trusted per run. REQUIRED when Vault is behind a private CA (LabUL
+        is), otherwise reading the vCenter credentials fails with
+        "x509: certificate signed by unknown authority". Also used for vCenter
+        itself when INSECURE_SKIP_VERIFY is "false".
+      optional: true
+  params:
+    - name: ACTION
+      description: >-
+        promote — the full golden-image swap (see PROMOTE below).
+        rename / move / delete — single primitives on SOURCE.
+      type: string
+      default: "promote"
+
+    # --- promote ---------------------------------------------------------
+    - name: TEMPLATE_NAME
+      description: >-
+        the freshly built template to promote, e.g.
+        "ubuntu24-base-20260721-1131". This is the `template-name` result
+        emitted by execute-packer.
+      type: string
+      default: ""
+    - name: GOLDEN_NAME
+      description: >-
+        the name the golden image is published under, e.g. "sthings-u24".
+        This is what consumers reference, so it must match the platform
+        EnvironmentConfig's template map.
+      type: string
+      default: ""
+    - name: BUILD_FOLDER
+      description: >-
+        inventory path of the folder packer builds into, e.g.
+        "/LabUL/vm/stuttgart-things/packer"
+      type: string
+      default: ""
+    - name: GOLDEN_FOLDER
+      description: >-
+        inventory path of the folder golden images live in, e.g.
+        "/LabUL/vm/stuttgart-things/vm-templates"
+      type: string
+      default: ""
+    - name: PREVIOUS_SUFFIX
+      description: >-
+        suffix for the retained previous generation. Promotion keeps exactly
+        one, so a bad golden image is one rename away from being rolled back.
+      type: string
+      default: "-previous"
+
+    # --- primitives ------------------------------------------------------
+    - name: SOURCE
+      description: inventory path of the object to act on (rename/move/delete)
+      type: string
+      default: ""
+    - name: TARGET
+      description: >-
+        rename — the new NAME (not a path).
+        move — the destination FOLDER path.
+        delete — unused.
+      type: string
+      default: ""
+
+    # --- connection ------------------------------------------------------
+    - name: DATACENTER
+      description: vCenter datacenter, e.g. "/LabUL". Empty lets govc pick when there is only one.
+      type: string
+      default: ""
+    - name: INSECURE_SKIP_VERIFY
+      description: >-
+        skip vCenter TLS verification. Defaults to "true" because the
+        stuttgart-things vCenters present self-signed certificates. Set to
+        "false" AND bind the ca-certs workspace for the better posture —
+        skipping verification here hides exactly the class of failure that
+        workspace exists to surface.
+      type: string
+      default: "true"
+
+    # --- vault -----------------------------------------------------------
+    # The vCenter credentials are read from Vault at run time rather than
+    # mounted as their own Secret: the `vault` Secret is already wired into
+    # every packer PipelineRun, and packer's own templates read the same path,
+    # so this introduces no new credential convention to keep in sync.
+    #
+    # NOTE machineshop is deliberately NOT used, despite the legacy GH Action
+    # doing so: it is not in this image (the rebase onto sthings-ansible
+    # dropped it). curl + jq are, and a Vault KV v2 read is one GET.
+    - name: VAULT_SECRET_PATH
+      description: Vault KV v2 read path holding the vCenter credentials
+      type: string
+      default: "cloud/data/vsphere"
+    - name: VAULT_KEY_USERNAME
+      description: key in the Vault secret holding the vCenter username
+      type: string
+      default: "username"
+    - name: VAULT_KEY_PASSWORD
+      description: key in the Vault secret holding the vCenter password
+      type: string
+      default: "password"
+    - name: VAULT_KEY_SERVER
+      description: key in the Vault secret holding the vCenter host/IP
+      type: string
+      default: "ip"
+    - name: vault-secret-name
+      description: name of the vault secret
+      type: string
+      default: "vault"
+    - name: vault-secret-key-addr
+      description: vault addr key in the secret
+      type: string
+      default: "VAULT_ADDR"
+    - name: vault-secret-key-token
+      description: vault token key in the secret
+      type: string
+      default: "VAULT_TOKEN"
+    - name: vault-secret-key-namespace
+      description: vault namespace key in the secret
+      type: string
+      default: "VAULT_NAMESPACE"
+
+    - name: USER_HOME
+      description: absolute path to the user's home directory
+      type: string
+      default: "/home/nonroot"
+    - name: WORKING_IMAGE
+      description: >-
+        image providing govc, curl and jq. Must be >= 2.0.0 — govc was added
+        in that image version.
+      type: string
+      default: "ghcr.io/stuttgart-things/sthings-packer:2.0.0"
+
+  results:
+    - name: action-performed
+      description: the govc action that was executed
+    - name: promoted-template
+      description: >-
+        inventory path the golden image now lives at. Empty for the
+        primitives.
+    - name: previous-template
+      description: >-
+        inventory path the superseded golden image was renamed to, or empty
+        when there was none (first-ever promotion). Roll back by renaming this
+        back to GOLDEN_NAME.
+
+  stepTemplate:
+    image: "$(params.WORKING_IMAGE)"
+    workingDir: /tmp
+    env:
+      - name: HOME
+        value: $(params.USER_HOME)
+      # Per-run CA trust, same contract as execute-packer/execute-tofu: the
+      # bundle is written at runtime, never baked into the image.
+      - name: SSL_CERT_FILE
+        value: /tmp/.tekton-ca-bundle.crt
+    securityContext:
+      privileged: false
+      runAsNonRoot: true
+      runAsUser: 65532
+    computeResources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+
+  steps:
+    # ONE step on purpose. Building the CA bundle, reading the credentials and
+    # running govc are separate concerns, but splitting them across steps would
+    # mean persisting the vCenter password to a shared volume for the next
+    # container to pick up. Keeping it in one process means the password only
+    # ever lives in this step's environment.
+    - name: govc-action
+      env:
+        - name: ACTION
+          value: $(params.ACTION)
+        - name: TEMPLATE_NAME
+          value: $(params.TEMPLATE_NAME)
+        - name: GOLDEN_NAME
+          value: $(params.GOLDEN_NAME)
+        - name: BUILD_FOLDER
+          value: $(params.BUILD_FOLDER)
+        - name: GOLDEN_FOLDER
+          value: $(params.GOLDEN_FOLDER)
+        - name: PREVIOUS_SUFFIX
+          value: $(params.PREVIOUS_SUFFIX)
+        - name: SOURCE
+          value: $(params.SOURCE)
+        - name: TARGET
+          value: $(params.TARGET)
+        - name: GOVC_DATACENTER
+          value: $(params.DATACENTER)
+        - name: GOVC_INSECURE
+          value: $(params.INSECURE_SKIP_VERIFY)
+        - name: VAULT_SECRET_PATH
+          value: $(params.VAULT_SECRET_PATH)
+        - name: VAULT_KEY_USERNAME
+          value: $(params.VAULT_KEY_USERNAME)
+        - name: VAULT_KEY_PASSWORD
+          value: $(params.VAULT_KEY_PASSWORD)
+        - name: VAULT_KEY_SERVER
+          value: $(params.VAULT_KEY_SERVER)
+        - name: CA_CERTS_BOUND
+          value: $(workspaces.ca-certs.bound)
+        - name: CA_CERTS_PATH
+          value: $(workspaces.ca-certs.path)
+        - name: VAULT_ADDR
+          valueFrom:
+            secretKeyRef:
+              key: $(params.vault-secret-key-addr)
+              name: $(params.vault-secret-name)
+              optional: true
+        - name: VAULT_TOKEN
+          valueFrom:
+            secretKeyRef:
+              key: $(params.vault-secret-key-token)
+              name: $(params.vault-secret-name)
+              optional: true
+        - name: VAULT_NAMESPACE
+          valueFrom:
+            secretKeyRef:
+              key: $(params.vault-secret-key-namespace)
+              name: $(params.vault-secret-name)
+              optional: true
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        # ---------------------------------------------------------------
+        # CA trust
+        # ---------------------------------------------------------------
+        BUNDLE="${SSL_CERT_FILE}"
+        : > "${BUNDLE}"
+        if [ -f /etc/ssl/certs/ca-certificates.crt ]; then
+          cat /etc/ssl/certs/ca-certificates.crt >> "${BUNDLE}"
+        fi
+        if [ "${CA_CERTS_BOUND}" = "true" ]; then
+          found=0
+          for crt in "${CA_CERTS_PATH}"/*.crt "${CA_CERTS_PATH}"/*.pem; do
+            [ -f "${crt}" ] || continue
+            printf '\n' >> "${BUNDLE}"
+            cat "${crt}" >> "${BUNDLE}"
+            found=1
+          done
+          echo "ca-certs workspace bound (private CAs found: ${found})"
+        else
+          echo "no ca-certs workspace bound - system trust store only"
+        fi
+        # govc reads its own variable rather than SSL_CERT_FILE.
+        export GOVC_TLS_CA_CERTS="${BUNDLE}"
+
+        # ---------------------------------------------------------------
+        # vCenter credentials from Vault
+        # ---------------------------------------------------------------
+        [ -n "${VAULT_ADDR:-}" ] || { echo "ERROR: VAULT_ADDR is empty - is the '$(params.vault-secret-name)' Secret present?" >&2; exit 1; }
+        [ -n "${VAULT_TOKEN:-}" ] || { echo "ERROR: VAULT_TOKEN is empty. packer's vault() and this task both need a TOKEN; ROLE_ID/SECRET_ID alone are not enough." >&2; exit 1; }
+
+        NS_HEADER=()
+        [ -n "${VAULT_NAMESPACE:-}" ] && NS_HEADER=(-H "X-Vault-Namespace: ${VAULT_NAMESPACE}")
+
+        HTTP_CODE=$(curl -sS --cacert "${BUNDLE}" -o /tmp/vault.json -w '%{http_code}' \
+          -H "X-Vault-Token: ${VAULT_TOKEN}" "${NS_HEADER[@]}" \
+          "${VAULT_ADDR%/}/v1/${VAULT_SECRET_PATH}")
+        if [ "${HTTP_CODE}" != "200" ]; then
+          # Never echo the body: a Vault error response can quote request data.
+          echo "ERROR: reading ${VAULT_SECRET_PATH} from Vault returned HTTP ${HTTP_CODE}" >&2
+          exit 1
+        fi
+
+        GOVC_USERNAME=$(jq -r --arg k "${VAULT_KEY_USERNAME}" '.data.data[$k] // empty' /tmp/vault.json)
+        GOVC_PASSWORD=$(jq -r --arg k "${VAULT_KEY_PASSWORD}" '.data.data[$k] // empty' /tmp/vault.json)
+        VC_SERVER=$(jq -r --arg k "${VAULT_KEY_SERVER}" '.data.data[$k] // empty' /tmp/vault.json)
+        rm -f /tmp/vault.json
+        for v in GOVC_USERNAME GOVC_PASSWORD VC_SERVER; do
+          [ -n "${!v}" ] || { echo "ERROR: ${VAULT_SECRET_PATH} has no usable value for ${v}" >&2; exit 1; }
+        done
+        export GOVC_USERNAME GOVC_PASSWORD
+        export GOVC_URL="https://${VC_SERVER}/sdk"
+        echo "vCenter: ${VC_SERVER} (insecure=${GOVC_INSECURE})"
+
+        # ---------------------------------------------------------------
+        # helpers
+        # ---------------------------------------------------------------
+        # `govc ls` prints the path when the object exists and nothing when it
+        # does not. Errors are swallowed so a missing object reads as absent
+        # rather than aborting under set -e.
+        exists() { [ -n "$(govc ls "$1" 2>/dev/null || true)" ]; }
+
+        # object.rename / object.destroy / object.mv are used rather than
+        # vm.change / vm.markasvm+vm.destroy: these operate on the managed
+        # object directly, so they work on TEMPLATES without first converting
+        # them back into VMs (which needs a resource pool to convert into).
+        require() { exists "$1" || { echo "ERROR: not found in vCenter: $1" >&2; exit 1; }; }
+
+        case "${ACTION}" in
+          promote)
+            for v in TEMPLATE_NAME GOLDEN_NAME BUILD_FOLDER GOLDEN_FOLDER; do
+              [ -n "${!v}" ] || { echo "ERROR: ACTION=promote requires ${v}" >&2; exit 1; }
+            done
+
+            SRC="${BUILD_FOLDER%/}/${TEMPLATE_NAME}"
+            GOLD="${GOLDEN_FOLDER%/}/${GOLDEN_NAME}"
+            PREV_NAME="${GOLDEN_NAME}${PREVIOUS_SUFFIX}"
+            PREV="${GOLDEN_FOLDER%/}/${PREV_NAME}"
+
+            # --- preflight: every check BEFORE the first mutation, so a
+            # --- typo fails with vCenter untouched rather than half-swapped.
+            require "${SRC}"
+            require "${GOLDEN_FOLDER}"
+
+            # Refuse to run against a half-promoted inventory. If the golden
+            # name is free but a -previous exists, an earlier promote died
+            # between demote and promote -- and that -previous IS the last
+            # known-good image. Destroying it (step 1 below) would throw away
+            # the only remaining copy.
+            if ! exists "${GOLD}" && exists "${PREV}"; then
+              echo "ERROR: ${GOLD} is missing but ${PREV} exists." >&2
+              echo "       A previous promote left the inventory half-swapped and ${PREV_NAME}" >&2
+              echo "       is now the only good image. Rename it back to ${GOLDEN_NAME} before retrying:" >&2
+              echo "         govc object.rename '${PREV}' '${GOLDEN_NAME}'" >&2
+              exit 1
+            fi
+
+            echo "=========================================="
+            echo "PROMOTE ${TEMPLATE_NAME} -> ${GOLDEN_NAME}"
+            echo "=========================================="
+
+            # 1. drop the generation we are about to replace
+            if exists "${PREV}"; then
+              echo "-> destroying superseded ${PREV}"
+              govc object.destroy "${PREV}"
+            else
+              echo "-> no existing ${PREV_NAME}, nothing to destroy"
+            fi
+
+            # 2. demote the current golden. This FREES THE NAME before the new
+            #    template takes it. The old workflow renamed the new one first,
+            #    leaving two objects called ${GOLDEN_NAME} in different folders
+            #    -- legal in vCenter, but anything resolving templates by name
+            #    instead of by inventory path (data.vsphere_virtual_machine in
+            #    the vsphere-vm module, notably) can then match the wrong one.
+            PREVIOUS_RESULT=""
+            if exists "${GOLD}"; then
+              echo "-> demoting ${GOLD} to ${PREV_NAME}"
+              govc object.rename "${GOLD}" "${PREV_NAME}"
+              PREVIOUS_RESULT="${PREV}"
+            else
+              echo "-> no existing ${GOLDEN_NAME}, first promotion"
+            fi
+
+            # 3. take the golden name
+            echo "-> renaming ${SRC} to ${GOLDEN_NAME}"
+            govc object.rename "${SRC}" "${GOLDEN_NAME}"
+            RENAMED="${BUILD_FOLDER%/}/${GOLDEN_NAME}"
+
+            # 4. move it where consumers look
+            echo "-> moving ${RENAMED} into ${GOLDEN_FOLDER}"
+            govc object.mv "${RENAMED}" "${GOLDEN_FOLDER}"
+
+            require "${GOLD}"
+            echo "=========================================="
+            echo "promoted: ${GOLD}"
+            [ -n "${PREVIOUS_RESULT}" ] && echo "rollback:  govc object.rename '${PREVIOUS_RESULT}' '${GOLDEN_NAME}'"
+            echo "=========================================="
+            printf '%s' "${GOLD}" > "$(results.promoted-template.path)"
+            printf '%s' "${PREVIOUS_RESULT}" > "$(results.previous-template.path)"
+            ;;
+
+          rename)
+            [ -n "${SOURCE}" ] && [ -n "${TARGET}" ] || { echo "ERROR: ACTION=rename requires SOURCE and TARGET" >&2; exit 1; }
+            require "${SOURCE}"
+            govc object.rename "${SOURCE}" "${TARGET}"
+            echo "renamed ${SOURCE} -> ${TARGET}"
+            printf '%s' "" > "$(results.promoted-template.path)"
+            printf '%s' "" > "$(results.previous-template.path)"
+            ;;
+
+          move)
+            [ -n "${SOURCE}" ] && [ -n "${TARGET}" ] || { echo "ERROR: ACTION=move requires SOURCE and TARGET" >&2; exit 1; }
+            require "${SOURCE}"
+            require "${TARGET}"
+            govc object.mv "${SOURCE}" "${TARGET}"
+            echo "moved ${SOURCE} -> ${TARGET}"
+            printf '%s' "" > "$(results.promoted-template.path)"
+            printf '%s' "" > "$(results.previous-template.path)"
+            ;;
+
+          delete)
+            # Deliberately NOT tolerant of a missing object, and deliberately
+            # not `|| true`. The legacy workflow ignored delete failures and
+            # carried on to the move, which produced a half-promoted vCenter
+            # with duplicate names and no error anywhere.
+            [ -n "${SOURCE}" ] || { echo "ERROR: ACTION=delete requires SOURCE" >&2; exit 1; }
+            require "${SOURCE}"
+            govc object.destroy "${SOURCE}"
+            echo "destroyed ${SOURCE}"
+            printf '%s' "" > "$(results.promoted-template.path)"
+            printf '%s' "" > "$(results.previous-template.path)"
+            ;;
+
+          *)
+            echo "ERROR: unsupported ACTION '${ACTION}' (expected promote, rename, move or delete)" >&2
+            exit 1
+            ;;
+        esac
+
+        printf '%s' "${ACTION}" > "$(results.action-performed.path)"


### PR DESCRIPTION
Steps 4 and 5 of #71, in one PR because they are genuinely coupled: `execute-govc` needs a `sthings-packer` image that *has* govc, and adding govc is exactly the change the old tagging scheme could not express.

---

# Step 4 — decouple the image version

The published tag came from `ARG PACKER_VERSION`, so **any image-content change at the same packer version republished the same tag with different contents**. Anyone pinned to it silently got a different image, and there was no tag that could say "the image changed" — which is also how `LABEL version` drifted into naming `1.16.0`, a version never published (#68). Adding govc would have overwritten `:1.15.1` for a third time.

| Tag | Meaning | Pin it? |
|---|---|---|
| `:2.0.0` | `ARG IMAGE_VERSION` — this image, published once | **yes** |
| `:packer-1.15.1` | `ARG PACKER_VERSION` — floating alias | no |
| `:latest` | floating | no |

The packer alias is **prefixed** so it can never again be confused with an image version — a bare `:1.15.1` used to mean both. Tags at and below `:1.15.1` are no longer written to, so existing pins **freeze** rather than break.

Both `LABEL`s now interpolate their `ARG`, so they cannot drift from what was built. The publish job **refuses to overwrite** an existing `:<IMAGE_VERSION>`; its login is a separate step because a missing tag and an auth failure both make `docker manifest inspect` exit non-zero, and conflating them would let a broken token wave an overwrite through.

Verified by building locally: `version=2.0.0`, `packer.version=1.15.1` (both from ARGs), govc 0.53.0, packer 1.15.1, xorriso 1.5.6, ansible-playbook core 2.21.2.

---

# Step 5 — `execute-govc` + `promote-packer-template`

## Promotion keeps one generation

The existing GH Action deletes the old golden template outright. An image that passes its smoke test but turns out broken in real use then has nothing to fall back to.

```
1. destroy <golden>-previous, if present
2. rename  <golden>          -> <golden>-previous
3. rename  <fresh build>     -> <golden>
4. move    it into the golden folder
```

Rollback is a single rename, and the task **prints that exact command** on success. Same number of govc calls as today.

This ordering also closes a hazard in the old workflow, which renamed the *new* template to the golden name **before** deleting the old one — leaving two objects called `<golden>` in different folders. vCenter allows it, but anything resolving templates by name rather than inventory path (notably `data.vsphere_virtual_machine` in the `vsphere-vm` module) can match the wrong one. Freeing the name first removes the window.

## Two refusals, both verified to abort with **zero** vCenter mutations

- **Preflight before mutation** — every existence check runs before the first write, so a typo fails with the inventory untouched.
- **Half-promoted state** — if `<golden>` is missing while `<golden>-previous` exists, an earlier promote died between demote and promote, and that `-previous` is then the *only* good image. Step 1 would destroy it. The task refuses and prints the rename to recover.

`delete` does **not** tolerate a missing object and is not `|| true`. The legacy workflow ignored delete failures and carried on to the move, producing a half-promoted vCenter with duplicate names and no error anywhere.

## Implementation notes

- `object.rename`/`object.destroy`/`object.mv` rather than dagger's `vm.change` and `vm.markasvm`+`vm.destroy`: these act on the managed object directly, so they work on **templates** without converting them back to VMs first (which needs a resource pool to convert into).
- Credentials are read from Vault at run time with curl+jq, from the same path packer's own templates use — no new secret convention.
- **One step on purpose**: splitting CA setup / credential read / govc across steps would mean persisting the vCenter password to a shared volume for the next container.
- **#71 said to use machineshop — it is not in the image.** The #67 rebase onto `sthings-ansible` dropped it. Found while building locally.

## Verification

- `shellcheck` clean.
- Promote logic exercised against a **stubbed inventory**: existing golden + previous → exactly 4 ops in the right order, two generations kept, and no moment where two objects share the golden name; first promotion → 2 ops; both refusals → 0 mutations.
- Both manifests accepted by a real Tekton via `kubectl apply --dry-run=server`.

---

## Merge order matters

1. Merge this → the publish job builds and pushes `:2.0.0`.
2. **Cut tag `v0.10.0`.** `pipelines/promote-packer-template.yaml` pins the task at `v0.10.0`; until that tag exists the git resolver cannot fetch `tasks/execute-govc.yaml`.
3. Follow-up: flip `execute-packer`, `build-packer-template` and `kcl/packer/main.k` from `:1.15.1` to `:2.0.0`, and add the promote step to the `PackerRelease` XR so it runs gated on the smoke test.

Nothing here has been run against real vCenter yet — that needs the published image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TrLpL4ziRqUDZeTqeMyuF