### PR TITLE
fix(kcl/packer): derive the Object name from pipelineRunName

### DIFF
--- a/kcl/packer/CLAUDE.md
+++ b/kcl/packer/CLAUDE.md
@@ -71,8 +71,16 @@ The pinned version MUST be published or the Configuration's verify CI fails
 with `failed to resolve <v>: ...kcl-tekton-pr-packer:<v>: not found`. Order:
 bump `kcl.mod` → `kcl mod push` → bump the pin in the consumer.
 
-**The ghcr package is PRIVATE** (unlike the ansible module's `kcl-tekton-pr`,
-which is public). function-kcl pulls anonymously, so any Composition pinning
-this module fails to render with `401 unauthorized` until the package
-visibility is flipped to public in the GHCR UI — there is no REST endpoint for
-it. This is why `cicd/packer-build` cannot render end to end yet.
+**The ghcr package must stay PUBLIC.** function-kcl pulls anonymously, so any
+Composition pinning this module fails to render with `401 unauthorized` the
+moment the package is private. A new package defaults to private, and the fix
+is UI-only — `PATCH /orgs/{org}/packages/container/{pkg}` returns 404. Check
+after every first push of a new package:
+
+```bash
+T=$(curl -s "https://ghcr.io/token?scope=repository:stuttgart-things/kcl-tekton-pr-packer:pull" | jq -r .token)
+curl -s -o /dev/null -w '%{http_code}\n' -H "Authorization: Bearer $T" \
+  https://ghcr.io/v2/stuttgart-things/kcl-tekton-pr-packer/manifests/<version>
+```
+
+200 = public, 401 = private.

--- a/kcl/packer/kcl.mod
+++ b/kcl/packer/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-tekton-pr-packer"
 edition = "v0.11.2"
-version = "0.5.0"
+version = "0.6.0"
 
 [dependencies]
 tekton-pipelines = "1.0.0"

--- a/kcl/packer/kcl.mod
+++ b/kcl/packer/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-tekton-pr-packer"
 edition = "v0.11.2"
-version = "0.6.0"
+version = "0.6.1"
 
 [dependencies]
 tekton-pipelines = "1.0.0"

--- a/kcl/packer/main.k
+++ b/kcl/packer/main.k
@@ -102,7 +102,19 @@ assert _storageAccessModes in ["ReadWriteOnce", "ReadWriteMany", "ReadOnlyMany"]
 
 # --- Crossplane wrapper settings ---
 _wrapInCrossplane = _flat_params?.wrapInCrossplane or option("wrapInCrossplane") or False
-_crossplaneObjectName = _flat_params?.crossplaneObjectName or option("crossplaneObjectName") or "packer-build-run"
+# Derived from pipelineRunName rather than a fixed literal: the Object name
+# must be unique per XR, or two PackerBuilds in one namespace compose the same
+# Object and the second one never syncs --
+#   ReconcileError: Unsynced resources: packer-build-run
+# with no event naming the collision and no PipelineRun behind the XR.
+#
+# The unnamed case deliberately keeps the old literal instead of reaching for
+# the timestamped fallback below: that value is recomputed from datetime.now()
+# on every render, so using it here would rename the Object each reconcile and
+# trade a collision for unbounded churn. An XR that wants to coexist with
+# others sets pipelineRunName (as cicd/packer-release does).
+_defaultObjectName = "{}-run".format(_pipelineRunName) if _pipelineRunName else "packer-build-run"
+_crossplaneObjectName = _flat_params?.crossplaneObjectName or option("crossplaneObjectName") or _defaultObjectName
 _crossplaneNamespace = _flat_params?.crossplaneNamespace or option("crossplaneNamespace") or "default"
 _crossplaneProviderConfig = _flat_params?.crossplaneProviderConfig or option("crossplaneProviderConfig") or "kubernetes-provider"
 _crossplaneTimeout = _flat_params?.crossplaneTimeout or option("crossplaneTimeout") or "120"

--- a/kcl/packer/main.k
+++ b/kcl/packer/main.k
@@ -102,6 +102,7 @@ assert _storageAccessModes in ["ReadWriteOnce", "ReadWriteMany", "ReadOnlyMany"]
 
 # --- Crossplane wrapper settings ---
 _wrapInCrossplane = _flat_params?.wrapInCrossplane or option("wrapInCrossplane") or False
+
 # Derived from pipelineRunName rather than a fixed literal: the Object name
 # must be unique per XR, or two PackerBuilds in one namespace compose the same
 # Object and the second one never syncs --


### PR DESCRIPTION
The Crossplane Object wrapper defaulted its name to the literal `"packer-build-run"`, so two `PackerBuild` XRs in one namespace composed the *same* Object. The second never syncs:

```
PackerRelease/ubuntu24-collbump          Creating: Unready resources: ubuntu24-collbump-build
└─ PackerBuild/ubuntu24-collbump-build   ReconcileError: Unsynced resources: packer-build-run
   └─ Object/packer-build-run            Available     ← owned by the other composite
```

Nothing names the collision — no event, no message mentioning the other owner. The XR sits in `phase: Building` with no PipelineRun behind it. It cost 20 minutes to notice, and only because `kubectl get pipelinerun` was unexpectedly empty.

Found via crossplane-configurations #137, which worked around it in `packer-release` by setting `crossplaneObjectName` explicitly. This fixes the *default*, so a bare `PackerBuild` is safe too.

### Why the unnamed case keeps the old literal

`pipelineRunName` is optional, and when it is unset the PipelineRun name falls back to `build-packer-template-<md5(now)>`. Reusing that for the Object name would rename the Object on **every render**, trading a collision for unbounded churn. So:

| `crossplaneObjectName` | `pipelineRunName` | Object name |
|---|---|---|
| set | — | as given |
| unset | set | `<pipelineRunName>-run` |
| unset | unset | `packer-build-run` (unchanged) |

All three verified with `kcl run`.

(Separately worth noting: an XR that leaves `pipelineRunName` unset already gets a *new* PipelineRun name every reconcile from that same timestamp. That is its own problem and not touched here.)

### Published

`kcl.mod` 0.5.0 → **0.6.0**, pushed to `oci://ghcr.io/stuttgart-things/kcl-tekton-pr-packer` and confirmed anonymously pullable (HTTP 200) — function-kcl pulls without credentials, so a private package would fail every render with `401`. The consumer pin in `cicd/packer-build` follows in a separate PR, per the documented order: bump `kcl.mod` → `kcl mod push` → bump the pin.

Also corrects `CLAUDE.md`, which still claimed the package is private and that `packer-build` therefore cannot render end to end. It has been public since the visibility was flipped, and packer-build has since built, tested and promoted a real image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TrLpL4ziRqUDZeTqeMyuF