### PR TITLE
fix(kcl/ansible): reclaim Delete on the wrapped PipelineRun Object

### DIFF
--- a/kcl/ansible/kcl.mod
+++ b/kcl/ansible/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-tekton-pr"
 edition = "v0.11.2"
-version = "0.11.0"
+version = "0.12.0"
 
 [dependencies]
 tekton-pipelines = "1.0.0"

--- a/kcl/ansible/main.k
+++ b/kcl/ansible/main.k
@@ -198,12 +198,21 @@ _crossplaneObject = {
         }
     }
     spec = {
-        # A PipelineRun is one-shot and Tekton rejects any spec update once it
-        # completes. The default ["*"] claims Update, so provider-kubernetes'
-        # observe dry-run SSA gets denied by the webhook, the observe errors and
-        # the finalizer is never released — deleting the XR after a successful
-        # run strands the Object forever. Create it, watch it, never touch it.
-        managementPolicies = ["Observe", "Create"]
+        # Spelled out rather than left at the default ["*"], and BOTH halves of
+        # this list matter.
+        #
+        # Update is excluded: a PipelineRun is one-shot and Tekton rejects any
+        # spec update once it completes. Claiming Update makes
+        # provider-kubernetes' observe dry-run SSA get denied by the webhook,
+        # the observe errors, the finalizer is never released, and deleting the
+        # XR after a successful run strands the Object forever.
+        #
+        # Delete is included: without it provider-kubernetes releases the Object
+        # without touching the external resource, so the PipelineRun outlives
+        # the XR with no owner reference and no finalizer — nothing in the
+        # cluster ever collects it. 0.9.0 dropped Update and Delete together and
+        # traded a stranded Object for a stranded PipelineRun (issue #75).
+        managementPolicies = ["Observe", "Create", "Delete"]
         forProvider = {
             manifest = _pipelineRun
         }


### PR DESCRIPTION
Fixes #75.

`0.9.0` (#60) dropped `Update` and `Delete` together:

```kcl
managementPolicies = ["Observe", "Create"]
```

Dropping `Update` was right. A PipelineRun is one-shot, Tekton rejects any spec update once it completes, and claiming `Update` makes provider-kubernetes' observe dry-run SSA get denied by the webhook — the observe errors, the finalizer is never released, and the Object is stranded forever.

Dropping `Delete` was collateral. Without it provider-kubernetes releases the Object without touching the external resource, so the PipelineRun outlives the XR with **no owner reference and no finalizer** — nothing in the cluster will ever collect it. A stranded Object was traded for a stranded PipelineRun.

Observed on kind1 after deleting three `PackerRelease` XRs:

```
NAME                             SUCCEEDED   COMPLETED
ubuntu24-collbump-test-ansible   True        2026-07-22T08:56:12Z
ubuntu24-factsfix-test-ansible   True        2026-07-22T10:34:13Z
ubuntu24-labul-test-ansible      True        2026-07-22T05:10:03Z
```

The oldest was 5h41m past the deletion of the XR that created it.

```kcl
managementPolicies = ["Observe", "Create", "Delete"]
```

`Delete` does not reintroduce the strand: the finalizer path issues a delete, not the SSA dry-run update the webhook rejects. The comment in `main.k` now spells out why *both* halves of the list are deliberate, so the next person removing one of them sees what it costs.

### Bundled behaviour change, stated on purpose

The consumer (`crossplane-configurations/cicd/ansible-run`) pins `0.9.0`. Moving it to `0.12.0` also picks up the only other change since then — the default `pipelineRevision` for the pipeline definition:

```
v0.7.0  ->  v0.9.0
```

`ansible-run-defaults` on kind1 does not set `pipelineRevision`, so the module default applies and this **will** take effect there. It is a sensible move (v0.7.0 is old), but it is not part of the fix and should not arrive unnoticed.

### Verification

Rendered locally:

```
$ kcl run main.k -D wrapInCrossplane=true
managementPolicies:
- Observe
- Create
- Delete
```

The behavioural test — that deleting an XR now removes its PipelineRun *and* that the Object still releases cleanly (i.e. #60's strand has not come back) — needs the consumer pin bumped and rolled onto a cluster. That follows in `crossplane-configurations`, and I will report both halves of the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TrLpL4ziRqUDZeTqeMyuF
