### PR TITLE
fix(kcl/ansible): derive the Object name from pipelineRunName

### DIFF
--- a/kcl/ansible/kcl.mod
+++ b/kcl/ansible/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-tekton-pr"
 edition = "v0.11.2"
-version = "0.12.0"
+version = "0.13.0"
 
 [dependencies]
 tekton-pipelines = "1.0.0"

--- a/kcl/ansible/main.k
+++ b/kcl/ansible/main.k
@@ -92,7 +92,29 @@ assert _decryptSops != "true" or _gitPath == "pipelines/execute-ansible-playbook
 
 # --- Crossplane wrapper settings ---
 _wrapInCrossplane = _flat_params?.wrapInCrossplane or option("wrapInCrossplane") or False
-_crossplaneObjectName = _flat_params?.crossplaneObjectName or option("crossplaneObjectName") or "tekton-pipeline-run"
+
+# Derived from pipelineRunName rather than a fixed literal: the Object name
+# must be unique per XR, or two AnsibleRuns in one namespace compose the same
+# Object and the second one never syncs --
+#   ReconcileError: Unsynced resources: tekton-pipeline-run
+# with no event naming the collision and no PipelineRun behind the XR.
+# pipelineRunName is XRD-required on AnsibleRun, so this path applies to every
+# XR; consumers that already set crossplaneObjectName (vm-provision does) are
+# unaffected.
+#
+# The unnamed case deliberately keeps the old literal instead of reaching for
+# the timestamped fallback below: that value is recomputed from datetime.now()
+# on every render, so using it here would rename the Object each reconcile and
+# trade a collision for unbounded churn.
+#
+# Deliberately the pipelineRunName ITSELF, not a suffixed variant: that is
+# already what the only real consumer sets explicitly
+# (crossplane-configurations machinery/vm-provision), so adopting it as the
+# default changes nothing for existing runs, and it makes the claim already
+# printed in cicd/ansible-run/examples/xr-min.yaml true. An Object and a
+# PipelineRun are different kinds, so sharing a name costs nothing.
+_defaultObjectName = _pipelineRunName if _pipelineRunName else "tekton-pipeline-run"
+_crossplaneObjectName = _flat_params?.crossplaneObjectName or option("crossplaneObjectName") or _defaultObjectName
 _crossplaneNamespace = _flat_params?.crossplaneNamespace or option("crossplaneNamespace") or "default"
 _crossplaneProviderConfig = _flat_params?.crossplaneProviderConfig or option("crossplaneProviderConfig") or "kubernetes-provider"
 _crossplaneTimeout = _flat_params?.crossplaneTimeout or option("crossplaneTimeout") or "60"


### PR DESCRIPTION
Fixes #77. Same bug `kcl/packer` had, fixed there in #74.

The Object wrapper defaulted its name to the literal `"tekton-pipeline-run"`, so two `AnsibleRun` XRs in one namespace composed the *same* Object and the second never synced:

```
AnsibleRun/deletetest (default)           True   False   Creating: Unready resources: tekton-pipeline-run
└─ Object/tekton-pipeline-run (default)   True   False   Unavailable
```

No event names the collision, and no PipelineRun sits behind the XR.

### Why `pipelineRunName` itself, not `<name>-run`

`kcl/packer` uses a `-run` suffix, but here the plain name is better on three counts:

1. `machinery/vm-provision` **already sets exactly this** (`composition.yaml:184`, `crossplaneObjectName = _pipelineRunName`). Adopting it as the default is a no-op for every existing run — the rollout cannot churn Objects.
2. It makes the claim already printed in `cicd/ansible-run/examples/xr-min.yaml` true: `crossplaneObjectName=pipelineRunName -> KCL module defaults`. That comment has been describing intent, not behaviour.
3. `deletetest-run` → `deletetest-run-run` reads badly, and an Object and a PipelineRun are different kinds — sharing a name costs nothing.

### Paths, all rendered

| `crossplaneObjectName` | `pipelineRunName` | Object |
|---|---|---|
| set | — | as given (`explicit`) |
| unset | `deletetest-run` | `deletetest-run` |
| unset | unset | `tekton-pipeline-run` (unchanged) |

The unnamed case keeps the literal on purpose: the only other candidate is the timestamped PipelineRun fallback, recomputed from `datetime.now()` on every render, which would rename the Object each reconcile. `pipelineRunName` is XRD-required on `AnsibleRun`, so that path is unreachable from Crossplane anyway.

Published as `0.13.0`, confirmed anonymously pullable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TrLpL4ziRqUDZeTqeMyuF