### PR TITLE
feat(pipelines): add execute-tofu pipeline with Vault AppRole auth

### DIFF
--- a/pipelines/execute-tofu.yaml
+++ b/pipelines/execute-tofu.yaml
@@ -1,0 +1,169 @@
+---
+# execute-tofu — clone a repo, then run OpenTofu against a subdirectory of it,
+# authenticating to Vault via AppRole (role_id + secret_id from a Secret).
+#
+# The AppRole is the point: role_id/secret_id are long-lived login credentials,
+# but each run exchanges them for a SHORT-LIVED Vault token carrying only the
+# policy that AppRole is bound to. Nothing static and privileged is left behind,
+# which is exactly what a bootstrap step that provisions Vault auth backends
+# wants — mirrors execute-ansible-playbooks in shape.
+#
+# Everything resolves over the git resolver: this Pipeline references the tasks
+# by git, and a PipelineRun references this Pipeline by git.
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: execute-tofu
+spec:
+  workspaces:
+    - name: shared-workspace
+    - name: sshCredentials
+      optional: true
+    - name: caCerts
+      optional: true
+      description: >-
+        Optional workspace with private CA certificates trusted per run
+        (passed to execute-tofu's ca-certs workspace).
+  params:
+    # ---- source ----
+    - name: gitRepoUrl
+      type: string
+      default: ""
+      description: source git repo holding the OpenTofu configuration
+    - name: gitRevision
+      type: string
+      default: "main"
+      description: revision of the source git repo
+    - name: gitWorkspaceSubdirectory
+      type: string
+      default: ""
+      description: subdirectory the repo is cloned into on the workspace
+    # ---- tofu ----
+    - name: tofuAction
+      type: string
+      default: "plan"
+      description: opentofu action (plan, apply or destroy)
+    - name: subDirectory
+      type: string
+      default: ""
+      description: subdirectory of the workspace holding the tofu configuration
+    - name: autoApprove
+      type: string
+      default: "true"
+      description: skip interactive approval for apply/destroy
+    - name: tfVars
+      type: array
+      default: []
+      description: extra variables as key+-value pairs (written to tekton.auto.tfvars)
+    - name: tfVarsFile
+      type: string
+      default: ""
+      description: tfvars file as b64 (merged via *.auto.tfvars, wins over tfVars)
+    - name: backendConfig
+      type: array
+      default: []
+      description: backend-config key+-value pairs passed to tofu init
+    - name: initExtraArgs
+      type: string
+      default: ""
+      description: extra args appended to tofu init
+    - name: planExtraArgs
+      type: string
+      default: ""
+      description: extra args appended to tofu plan
+    - name: tofuLog
+      type: string
+      default: ""
+      description: TF_LOG level (TRACE/DEBUG/INFO/WARN/ERROR or empty)
+    - name: tofuWorkingImage
+      type: string
+      default: "ghcr.io/opentofu/opentofu:1.9.0"
+      description: the image opentofu runs on
+    - name: userHome
+      type: string
+      default: "/home/nonroot"
+      description: absolute path to the user's home directory
+    # ---- credentials ----
+    - name: vaultSecretName
+      type: string
+      default: "vault"
+      description: >-
+        Secret holding the Vault AppRole login material — keys VAULT_ADDR,
+        VAULT_ROLE_ID, VAULT_SECRET_ID (and optional VAULT_NAMESPACE).
+    - name: credentialsSecretName
+      type: string
+      default: "terraform-credentials"
+      description: optional Secret whose keys are exported as env for the tofu run
+  tasks:
+    - name: fetch-repository
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/tektoncd/catalog.git
+          # Pinned commit for supply-chain safety — same pin as
+          # execute-ansible-playbooks. Bump deliberately.
+          - name: revision
+            value: 7ea2968e224633b4967d60217b33bb4d38fa53d9 # pragma: allowlist secret (git commit SHA, not a secret)
+          - name: pathInRepo
+            value: task/git-clone/0.10/git-clone.yaml
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+        - name: ssh-directory
+          workspace: sshCredentials
+      params:
+        - name: deleteExisting
+          value: "true"
+        - name: revision
+          value: $(params.gitRevision)
+        - name: subdirectory
+          value: $(params.gitWorkspaceSubdirectory)
+        - name: url
+          value: $(params.gitRepoUrl)
+    - name: execute-tofu
+      runAfter:
+        - fetch-repository
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/stuttgart-things/stage-time.git
+          # stage-time self-reference stays on main so local task edits
+          # propagate; bumped to a tag on release like the ansible pipeline.
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/execute-tofu.yaml
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+        - name: ca-certs
+          workspace: caCerts
+      params:
+        - name: ACTION
+          value: $(params.tofuAction)
+        - name: SUB_DIRECTORY
+          value: $(params.subDirectory)
+        - name: AUTO_APPROVE
+          value: $(params.autoApprove)
+        - name: TF_VARS
+          value: $(params.tfVars[*])
+        - name: TF_VARS_FILE
+          value: $(params.tfVarsFile)
+        - name: BACKEND_CONFIG
+          value: $(params.backendConfig[*])
+        - name: INIT_EXTRA_ARGS
+          value: $(params.initExtraArgs)
+        - name: PLAN_EXTRA_ARGS
+          value: $(params.planExtraArgs)
+        - name: TF_LOG
+          value: $(params.tofuLog)
+        - name: WORKING_IMAGE
+          value: $(params.tofuWorkingImage)
+        - name: USER_HOME
+          value: $(params.userHome)
+        - name: vault-secret-name
+          value: $(params.vaultSecretName)
+        - name: credentials-secret-name
+          value: $(params.credentialsSecretName)

--- a/tests/tofu-vault-k8sauth/main.tf
+++ b/tests/tofu-vault-k8sauth/main.tf
@@ -1,34 +1,50 @@
 # Minimal end-to-end proof for the execute-tofu pipeline:
 #   git-clone -> tofu init/apply -> Vault AppRole login -> policy allows the op.
 #
-# It creates a single Kubernetes auth mount and reads it back. That exercises
-# exactly the vault-k8sauth-bootstrap policy path (sys/auth create + read) with
-# nothing else, and no kubeconfig/kubernetes provider — so a failure is
-# unambiguously the pipeline or the auth, not the surrounding module.
+# It creates one Kubernetes auth mount and reads it back — exactly the
+# vault-k8sauth-bootstrap policy path (sys/auth create + read), nothing else,
+# no kubeconfig/kubernetes provider. A failure is unambiguously the pipeline or
+# the auth, not the surrounding module.
+#
+# Auth: the generic auth_login block against the approle login path (the
+# established stuttgart-things pattern). role_id/secret_id arrive as
+# TF_VAR_vault_role_id / TF_VAR_vault_secret_id — the execute-tofu task injects
+# every key of its credentials Secret as env (envFrom), and Terraform maps
+# TF_VAR_* onto variables. VAULT_ADDR comes from the vault Secret.
 #
 # ACTION=apply creates the mount; ACTION=destroy removes it.
 
 terraform {
   required_providers {
     vault = {
-      source = "hashicorp/vault"
-      # Pinned to 3.x: auth_login_approle reads role_id/secret_id from the
-      # VAULT_ROLE_ID / VAULT_SECRET_ID env vars the execute-tofu task exports.
-      # v4/v5 reworked the auth blocks and reject auth_login_approle as written.
+      source  = "hashicorp/vault"
       version = "~> 3.25"
     }
   }
 }
 
+variable "vault_role_id" {
+  type        = string
+  description = "AppRole role_id (via TF_VAR_vault_role_id from the credentials Secret)"
+}
+
+variable "vault_secret_id" {
+  type        = string
+  sensitive   = true
+  description = "AppRole secret_id (via TF_VAR_vault_secret_id from the credentials Secret)"
+}
+
 provider "vault" {
-  # address from VAULT_ADDR (set by the execute-tofu task from the vault Secret)
+  # address from VAULT_ADDR (vault Secret, exported by the task)
   skip_tls_verify = true
 
-  # role_id / secret_id are read from VAULT_ROLE_ID / VAULT_SECRET_ID env,
-  # which the task exports from the same Secret. Nothing sensitive in tfvars.
-  # role_id / secret_id come from VAULT_ROLE_ID / VAULT_SECRET_ID (env),
-  # exported by the execute-tofu task from the vault Secret.
-  auth_login_approle {}
+  auth_login {
+    path = "auth/approle/login"
+    parameters = {
+      role_id   = var.vault_role_id
+      secret_id = var.vault_secret_id
+    }
+  }
 }
 
 variable "mount_path" {

--- a/tests/tofu-vault-k8sauth/main.tf
+++ b/tests/tofu-vault-k8sauth/main.tf
@@ -11,8 +11,11 @@
 terraform {
   required_providers {
     vault = {
-      source  = "hashicorp/vault"
-      version = ">= 3.21.0"
+      source = "hashicorp/vault"
+      # Pinned to 3.x: auth_login_approle reads role_id/secret_id from the
+      # VAULT_ROLE_ID / VAULT_SECRET_ID env vars the execute-tofu task exports.
+      # v4/v5 reworked the auth blocks and reject auth_login_approle as written.
+      version = "~> 3.25"
     }
   }
 }
@@ -23,9 +26,9 @@ provider "vault" {
 
   # role_id / secret_id are read from VAULT_ROLE_ID / VAULT_SECRET_ID env,
   # which the task exports from the same Secret. Nothing sensitive in tfvars.
-  auth_login_approle {
-    mount = "approle"
-  }
+  # role_id / secret_id come from VAULT_ROLE_ID / VAULT_SECRET_ID (env),
+  # exported by the execute-tofu task from the vault Secret.
+  auth_login_approle {}
 }
 
 variable "mount_path" {

--- a/tests/tofu-vault-k8sauth/main.tf
+++ b/tests/tofu-vault-k8sauth/main.tf
@@ -1,0 +1,44 @@
+# Minimal end-to-end proof for the execute-tofu pipeline:
+#   git-clone -> tofu init/apply -> Vault AppRole login -> policy allows the op.
+#
+# It creates a single Kubernetes auth mount and reads it back. That exercises
+# exactly the vault-k8sauth-bootstrap policy path (sys/auth create + read) with
+# nothing else, and no kubeconfig/kubernetes provider — so a failure is
+# unambiguously the pipeline or the auth, not the surrounding module.
+#
+# ACTION=apply creates the mount; ACTION=destroy removes it.
+
+terraform {
+  required_providers {
+    vault = {
+      source  = "hashicorp/vault"
+      version = ">= 3.21.0"
+    }
+  }
+}
+
+provider "vault" {
+  # address from VAULT_ADDR (set by the execute-tofu task from the vault Secret)
+  skip_tls_verify = true
+
+  # role_id / secret_id are read from VAULT_ROLE_ID / VAULT_SECRET_ID env,
+  # which the task exports from the same Secret. Nothing sensitive in tfvars.
+  auth_login_approle {
+    mount = "approle"
+  }
+}
+
+variable "mount_path" {
+  type        = string
+  default     = "pipeline-test-certmanager"
+  description = "Kubernetes auth mount this test creates"
+}
+
+resource "vault_auth_backend" "test" {
+  type = "kubernetes"
+  path = var.mount_path
+}
+
+output "mount_accessor" {
+  value = vault_auth_backend.test.accessor
+}

--- a/tests/tofu-vault-k8sauth/main.tf
+++ b/tests/tofu-vault-k8sauth/main.tf
@@ -38,6 +38,11 @@ provider "vault" {
   # address from VAULT_ADDR (vault Secret, exported by the task)
   skip_tls_verify = true
 
+  # The provider otherwise mints a short-lived child token via
+  # auth/token/create for its operations — which the vault-k8sauth-bootstrap
+  # policy deliberately forbids. Use the AppRole login token directly instead.
+  skip_child_token = true
+
   auth_login {
     path = "auth/approle/login"
     parameters = {


### PR DESCRIPTION
Adds an `execute-tofu` Pipeline that mirrors `execute-ansible-playbooks`: git-clone (tektoncd catalog, pinned) then the `execute-tofu` task, everything resolved over the **git resolver** — a PipelineRun references the Pipeline by git, the Pipeline references the tasks by git.

## Why

There was an `execute-tofu` *task* but no pipeline wiring clone + run together, the way `execute-ansible-playbooks` does for ansible.

The motivating use case: provisioning Vault Kubernetes auth backends for cert-manager as a **one-shot** step. Vault auth is **AppRole** — `role_id`/`secret_id` are long-lived login material, but each run exchanges them for a short-lived policy token, so nothing static and privileged is left behind. That is the right shape for a bootstrap step and avoids the static-token trap that expiring cert-manager issuers keep falling into.

## Verified end-to-end

Ran on a live cluster against a live Vault. A PipelineRun drove the whole chain and created a real Kubernetes auth mount:

```
git-clone (resolver) → tofu init → AppRole login → tofu apply
Apply complete! Resources: 1 added
mount_accessor = auth_kubernetes_...   (type=kubernetes, confirmed on Vault)
```

Then removed it again. `tests/tofu-vault-k8sauth` is the standalone proof: it creates one Kubernetes auth mount and reads it back — nothing else, no kubeconfig/kubernetes provider — so a failure is unambiguously the pipeline or the auth.

## Wiring notes worth keeping (all learned the hard way in testing)

- **Provider pinned to `~> 3.25`.** A bare `>= 3.21.0` pulls v5.x, which reworked the auth blocks.
- **Generic `auth_login` against `auth/approle/login`**, not `auth_login_approle` (which is not a valid provider block in any tested version). This is the established stuttgart-things pattern.
- **`role_id`/`secret_id` arrive as `TF_VAR_*`** — the task injects every key of its `credentials-secret-name` Secret as env (`envFrom`), and Terraform maps `TF_VAR_*` onto variables. `VAULT_ADDR` comes from the `vault` Secret.
- **`skip_child_token = true`** — the provider otherwise mints a limited child token via `auth/token/create`; a least-privilege bootstrap policy forbids that, so using the AppRole login token directly keeps the policy minimal.

## Files

- `pipelines/execute-tofu.yaml` — the Pipeline
- `tests/tofu-vault-k8sauth/main.tf` — minimal end-to-end proof config

## Follow-up

This pipeline is the substrate for a Crossplane `TofuRun` Configuration (analogous to `ansible-run`) that renders it as a PipelineRun — the deterministic, self-service way to provision Vault auth per cluster. Not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QSLXgANJSrsxSevzyH96EZ
