### PR TITLE
fix(examples): double-quote string tfVars value (HCL rejects single quotes)

### DIFF
--- a/.k2n/examples/tr-execute-tofu.yaml
+++ b/.k2n/examples/tr-execute-tofu.yaml
@@ -16,7 +16,11 @@ spec:
       value: "terraform"
     - name: TF_VARS
       value:
-        - "region+-'eu-central-1'"
+        # String values must be DOUBLE-quoted in the value half — the tfvars line
+        # is HCL (region = "eu-central-1"), and HCL rejects single quotes. Wrap the
+        # whole item in YAML single quotes so the inner double quotes survive.
+        # Numbers need no quotes (instance_count = 2 is a valid HCL number).
+        - 'region+-"eu-central-1"'
         - "instance_count+-2"
     - name: BACKEND_CONFIG
       value:


### PR DESCRIPTION
The `execute-tofu` TaskRun example passed `region+-'eu-central-1'` (single quotes). The `create-tfvars` step turns `key+-value` into `key = value` verbatim, so that produced the HCL line `region = 'eu-central-1'`, which OpenTofu rejects:

```
Error: Invalid character
  on tekton.auto.tfvars line 1:
   1: region = 'eu-central-1'
Single quotes are not valid. Use double quotes (") to enclose strings.
```

String values must be **double-quoted in the value half**; wrap the whole YAML item in single quotes so the inner double quotes survive:

```yaml
- 'region+-"eu-central-1"'   # -> region = "eu-central-1"
- "instance_count+-2"      # numbers need no quotes -> instance_count = 2
```

Verified by simulating the create-tfvars sed on the YAML values:

```
region+-"eu-central-1"  -> region = "eu-central-1"
instance_count+-2       -> instance_count = 2
```

Caught while applying a real TofuRun (crossplane-configurations `cicd/tofu-run`) through this pipeline on a live cluster — the single-quoted form failed `tofu init` before this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QSLXgANJSrsxSevzyH96EZ