### PR TITLE
feat(ansible): inject a Secret's keys as env vars into the playbook step

### DIFF
--- a/kcl/ansible/CLAUDE.md
+++ b/kcl/ansible/CLAUDE.md
@@ -36,7 +36,24 @@ oxr.spec.<field>  →  EnvironmentConfig (_env)  →  -D option  →  hardcoded 
 
 EnvironmentConfig provides shared *defaults* only (XR spec always wins) for:
 `gitRepoUrl`, `gitRevision`, `gitPath`, `storageClass`, `ansibleWorkingImage`,
-`namespace`, `ansibleExtraCollections`, `ansibleCredentialsSecretName`.
+`namespace`, `ansibleExtraCollections`, `ansibleCredentialsSecretName`,
+`extraEnvSecretName`.
+
+## Env injection (`extraEnvSecretName`)
+Names a Secret whose keys are injected verbatim as environment variables into
+the playbook step (`envFrom.secretRef`, `optional: true`) — for playbooks that
+read credentials via `lookup('env', ...)`, e.g. `SOPS_AGE_KEY` /
+`SOPS_GIT_TOKEN` in the machinery bootstrap.
+
+Deliberately one Secret *name*, not a list of `{envVar, secretName, key}`:
+**Tekton cannot render a variable number of `env` entries from an array
+param**, so a list would need a task param per variable. `envFrom` is applied
+by Kubernetes *before* `env`, so the explicitly named vars in the task
+(`ANSIBLE_PASSWORD`, `VAULT_*`) still win on a key collision.
+
+Empty by default and emitted into `_pipeline_params_override` **only when
+set** — Tekton rejects params a pipeline does not declare, so an unset value
+keeps XRs pinned to a pre-`v0.11.0` `pipelineRevision` renderable.
 
 ## Opt-in readiness
 `deriveReadiness` (default `false`): when true, the wrapped Object gets

--- a/kcl/ansible/README.md
+++ b/kcl/ansible/README.md
@@ -205,6 +205,7 @@ The following `data` keys are consumed (all optional):
 | `namespace`                  | Default Tekton namespace for the PipelineRun |
 | `ansibleExtraCollections`    | Default Ansible collections (JSON list) |
 | `ansibleCredentialsSecretName` | Default credentials Secret name |
+| `extraEnvSecretName`         | Default Secret injected as env vars into the playbook step |
 
 Precedence per field: explicit `oxr.spec` value → `EnvironmentConfig`
 value → flat `-D` option → hardcoded default. When no EnvironmentConfig

--- a/kcl/ansible/kcl.mod
+++ b/kcl/ansible/kcl.mod
@@ -1,7 +1,7 @@
 [package]
 name = "kcl-tekton-pr"
 edition = "v0.11.2"
-version = "0.13.0"
+version = "0.14.0"
 
 [dependencies]
 tekton-pipelines = "1.0.0"

--- a/kcl/ansible/main.k
+++ b/kcl/ansible/main.k
@@ -58,6 +58,17 @@ _ansibleVarsInventory = _flat_params?.ansibleVarsInventory or option("ansibleVar
 _ansibleVarsFile = _flat_params?.ansibleVarsFile or option("ansibleVarsFile") or []
 _ansibleCredentialsSecretName = _flat_params?.ansibleCredentialsSecretName or _env?.ansibleCredentialsSecretName or option("ansibleCredentialsSecretName") or "ansible-credentials"
 
+# Bulk env injection: every key of this Secret becomes an environment variable
+# in the playbook step, for playbooks that read credentials via
+# `lookup('env', ...)` (e.g. SOPS_AGE_KEY / SOPS_GIT_TOKEN in the machinery
+# bootstrap). Deliberately ONE secret name rather than a list of
+# {envVar, secretName, key}: Tekton cannot render a variable number of `env`
+# entries from an array param, so a list would need a param per variable.
+# Empty by default and only emitted when set — an unset value keeps the
+# rendered params byte-identical to today, so pipeline revisions that predate
+# this param (Tekton rejects params a pipeline does not declare) still work.
+_extraEnvSecretName = _flat_params?.extraEnvSecretName or _env?.extraEnvSecretName or option("extraEnvSecretName") or ""
+
 # Previously these only resolved from `-D` options via values.k, so setting
 # them in an XR spec (composition mode) was silently ignored. Extract them
 # here so `oxr.spec.<field>` is honoured, same precedence as the fields above.
@@ -176,6 +187,9 @@ _pipeline_params_override = {
     validateInventory = _validateInventory
     gitRepoUrl = _gitRepoUrl
     gitRevision = _gitRevision
+    # Only emitted when set, so older pipeline revisions stay renderable.
+    if _extraEnvSecretName:
+        extraEnvSecretName = _extraEnvSecretName
     # Only emit sops params when enabled — keeps the from-collections pipeline
     # (which doesn't declare them) unaffected; the clone pipeline defaults them.
     if _decryptSops == "true":

--- a/pipelines/execute-ansible-playbooks-from-collections.yaml
+++ b/pipelines/execute-ansible-playbooks-from-collections.yaml
@@ -92,6 +92,14 @@ spec:
       type: string
       default: "ANSIBLE_PASSWORD"
 
+    - name: extraEnvSecretName
+      type: string
+      default: "ansible-extra-env"
+      description: >-
+        Optional Secret whose keys are injected as environment variables into
+        the playbook step (for playbooks reading `lookup('env', ...)`).
+        Missing secret => no env vars, no failure.
+
   tasks:
     - name: execute-ansible
       taskRef:
@@ -162,3 +170,6 @@ spec:
 
         - name: ansible-credentials-password-key
           value: $(params.ansibleCredentialsPasswordKey)
+
+        - name: extra-env-secret-name
+          value: $(params.extraEnvSecretName)

--- a/pipelines/execute-ansible-playbooks.yaml
+++ b/pipelines/execute-ansible-playbooks.yaml
@@ -103,6 +103,13 @@ spec:
       type: string
       default: "ANSIBLE_PASSWORD"
       description: key for ansible password in the secret
+    - name: extraEnvSecretName
+      type: string
+      default: "ansible-extra-env"
+      description: >-
+        Optional Secret whose keys are injected as environment variables into
+        the playbook step (for playbooks reading `lookup('env', ...)`).
+        Missing secret => no env vars, no failure.
     # -------------------------------
     # SOPS decryption (runs after the git clone, before ansible)
     # -------------------------------
@@ -188,6 +195,8 @@ spec:
           value: $(params.ansibleCredentialsUserKey)
         - name: ansible-credentials-password-key
           value: $(params.ansibleCredentialsPasswordKey)
+        - name: extra-env-secret-name
+          value: $(params.extraEnvSecretName)
     - name: fetch-repository
       taskRef:
         resolver: git

--- a/tasks/execute-ansible.yaml
+++ b/tasks/execute-ansible.yaml
@@ -113,6 +113,17 @@ spec:
       description: key for ansible password in the secret
       type: string
       default: "ANSIBLE_PASSWORD"
+    - name: extra-env-secret-name
+      description: >-
+        Name of an optional Secret whose keys are injected verbatim as
+        environment variables into the playbook step. Every key becomes an env
+        var of the same name, so playbooks reading `lookup('env', 'FOO')` work
+        without adding a param per variable (Tekton cannot render a variable
+        number of `env` entries from an array param). Missing secret => no env
+        vars, no failure. Keys must be valid env var names or the Pod is
+        rejected.
+      type: string
+      default: "ansible-extra-env"
   results:
     - name: playbooks-executed
       description: number of playbooks successfully executed
@@ -346,6 +357,15 @@ spec:
     - name: run-ansible-playbook
       args:
         - $(params.PLAYBOOKS[*])
+      # Bulk env injection for playbooks that read credentials from the
+      # environment (e.g. SOPS_AGE_KEY / SOPS_GIT_TOKEN in the machinery
+      # bootstrap). Kubernetes applies envFrom BEFORE env, so the explicitly
+      # named vars below always win on a key collision — a stray
+      # ANSIBLE_PASSWORD in this secret cannot shadow the credentials secret.
+      envFrom:
+        - secretRef:
+            name: $(params.extra-env-secret-name)
+            optional: true
       env:
         # Disabled so first-contact SSH to freshly-provisioned targets does
         # not block on an interactive host-key prompt. Trade-off: no MITM


### PR DESCRIPTION
## Problem

Playbooks that read credentials from the **environment** have no way to get them through the ansible pipeline. Concretely: the machinery bootstrap play (`sthings.container.kind_machinery_profile`) reads `SOPS_AGE_KEY` and `SOPS_GIT_TOKEN` via `lookup('env', ...)`.

- `tasks/execute-ansible.yaml` sets only a fixed set of named env vars (`ANSIBLE_*`, `VAULT_*`).
- AnsibleRun's SOPS support is **file**-oriented — it mounts the age key as the `sopsKeys` workspace and decrypts files; it sets no env var. `SOPS_GIT_TOKEN` is unknown to it entirely.

So machinery can only be bootstrapped from the ansible CLI, not via an `AnsibleRun`.

## Change

A single new param, threaded task → both pipelines:

- task: `extra-env-secret-name` (default `ansible-extra-env`) → `envFrom.secretRef{optional: true}` on the `run-ansible-playbook` step
- pipelines: `extraEnvSecretName`, passed through
- `kcl-tekton-pr`: `extraEnvSecretName` (`oxr.spec` → EnvironmentConfig → `-D` → `""`), bumped to 0.14.0

Every key of the Secret becomes an env var of the same name.

## Why one Secret name, not `[{envVar, secretName, key}]`

**Tekton cannot render a variable number of `env` entries from an array param.** A list-shaped API would need a task param per variable — i.e. exactly the hardcoding this is meant to remove. `envFrom` gives arbitrarily many vars from one param.

Two properties that make this safe:

- Kubernetes applies `envFrom` **before** `env`, so the explicitly named vars in the task still win on a key collision — a stray `ANSIBLE_PASSWORD` in this Secret cannot shadow the credentials secret.
- `optional: true`: a missing Secret is a no-op, not a Pod failure. So the default name being present in every rendered PipelineRun costs nothing.

The KCL module emits the param **only when set**, so XRs pinned to a pipeline revision that predates it stay renderable (Tekton rejects params a pipeline does not declare).

## Validation

- All three manifests pass `kubectl apply --dry-run=server` against the real Tekton webhook on kind1 — this is what confirms `envFrom` is accepted on a v1 `Step` (it is in the v1 CRD schema).
- Module renders the param when set, omits it when unset.

## Follow-ups

1. The git-resolver self-refs still point at `v0.9.0`; they get bumped in the usual separate `chore: pin stage-time git-resolver self-refs to <tag>` commit once this is released (cf. #56, #66). Until then the new param is inert at runtime.
2. `crossplane-configurations`: `extraEnvSecretName` on the AnsibleRun XRD + `kcl-tekton-pr:0.14.0` pin (publish module before pinning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XW1BPvxyeuok5hoduEwG91