### PR TITLE
chore: pin ansible git-resolver self-refs to v0.11.0

### DIFF
--- a/kcl/ansible/main.k
+++ b/kcl/ansible/main.k
@@ -39,7 +39,7 @@ _gitPath = _flat_params?.gitPath or _env?.gitPath or option("gitPath") or "pipel
 # from the content source above so pointing gitRepoUrl at an external playbook repo
 # no longer drags the pipeline definition with it.
 _pipelineRepoUrl = _flat_params?.pipelineRepoUrl or _env?.pipelineRepoUrl or option("pipelineRepoUrl") or "https://github.com/stuttgart-things/stage-time.git"
-_pipelineRevision = _flat_params?.pipelineRevision or _env?.pipelineRevision or option("pipelineRevision") or "v0.9.0"
+_pipelineRevision = _flat_params?.pipelineRevision or _env?.pipelineRevision or option("pipelineRevision") or "v0.11.0"
 
 # SOPS decrypt-after-git-clone (execute-ansible-playbooks pipeline only). Off by
 # default. When "true", the sops params are passed AND the sopsKeys workspace is

--- a/pipelines/execute-ansible-playbooks-from-collections.yaml
+++ b/pipelines/execute-ansible-playbooks-from-collections.yaml
@@ -108,7 +108,7 @@ spec:
           - name: url
             value: https://github.com/stuttgart-things/stage-time.git
           - name: revision
-            value: v0.9.0
+            value: v0.11.0
           - name: pathInRepo
             value: tasks/execute-ansible.yaml
 

--- a/pipelines/execute-ansible-playbooks.yaml
+++ b/pipelines/execute-ansible-playbooks.yaml
@@ -147,7 +147,7 @@ spec:
           - name: url
             value: https://github.com/stuttgart-things/stage-time.git
           - name: revision
-            value: v0.9.0
+            value: v0.11.0
           - name: pathInRepo
             value: tasks/execute-ansible.yaml
       workspaces:
@@ -238,7 +238,7 @@ spec:
           - name: url
             value: https://github.com/stuttgart-things/stage-time.git
           - name: revision
-            value: v0.9.0
+            value: v0.11.0
           - name: pathInRepo
             value: tasks/decrypt-sops.yaml
       workspaces:


### PR DESCRIPTION
Follow-up to #81, same pattern as #56 / #66.

`v0.11.0` is the first tag whose pipelines declare `extraEnvSecretName` and whose `execute-ansible` task wires it to `envFrom`. Until the git-resolver refs point there, the new param is **inert at runtime**: the KCL module would emit it into a PipelineRun whose resolved pipeline (v0.9.0) does not declare it — and Tekton rejects params a pipeline doesn't declare.

Bumped in the ansible chain only:

- `pipelines/execute-ansible-playbooks.yaml` — `execute-ansible` + `decrypt-sops` task refs
- `pipelines/execute-ansible-playbooks-from-collections.yaml` — `execute-ansible` task ref
- `kcl/ansible/main.k` — `_pipelineRevision` default

The packer/buildah pipelines keep their own `v0.9.0` pins; they are unaffected and get bumped on their own schedule.

Next: publish `kcl-tekton-pr:0.14.0`, then bump the pin in `crossplane-configurations`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XW1BPvxyeuok5hoduEwG91