### PR TITLE
chore: re-pin ansible git-resolver self-refs to v0.11.1

### DIFF
--- a/kcl/ansible/main.k
+++ b/kcl/ansible/main.k
@@ -39,7 +39,7 @@ _gitPath = _flat_params?.gitPath or _env?.gitPath or option("gitPath") or "pipel
 # from the content source above so pointing gitRepoUrl at an external playbook repo
 # no longer drags the pipeline definition with it.
 _pipelineRepoUrl = _flat_params?.pipelineRepoUrl or _env?.pipelineRepoUrl or option("pipelineRepoUrl") or "https://github.com/stuttgart-things/stage-time.git"
-_pipelineRevision = _flat_params?.pipelineRevision or _env?.pipelineRevision or option("pipelineRevision") or "v0.11.0"
+_pipelineRevision = _flat_params?.pipelineRevision or _env?.pipelineRevision or option("pipelineRevision") or "v0.11.1"
 
 # SOPS decrypt-after-git-clone (execute-ansible-playbooks pipeline only). Off by
 # default. When "true", the sops params are passed AND the sopsKeys workspace is

--- a/pipelines/execute-ansible-playbooks-from-collections.yaml
+++ b/pipelines/execute-ansible-playbooks-from-collections.yaml
@@ -108,7 +108,7 @@ spec:
           - name: url
             value: https://github.com/stuttgart-things/stage-time.git
           - name: revision
-            value: v0.11.0
+            value: v0.11.1
           - name: pathInRepo
             value: tasks/execute-ansible.yaml
 

--- a/pipelines/execute-ansible-playbooks.yaml
+++ b/pipelines/execute-ansible-playbooks.yaml
@@ -147,7 +147,7 @@ spec:
           - name: url
             value: https://github.com/stuttgart-things/stage-time.git
           - name: revision
-            value: v0.11.0
+            value: v0.11.1
           - name: pathInRepo
             value: tasks/execute-ansible.yaml
       workspaces:
@@ -238,7 +238,7 @@ spec:
           - name: url
             value: https://github.com/stuttgart-things/stage-time.git
           - name: revision
-            value: v0.11.0
+            value: v0.11.1
           - name: pathInRepo
             value: tasks/decrypt-sops.yaml
       workspaces:


### PR DESCRIPTION
Fixes an ordering mistake in #82.

`v0.11.0` was tagged **before** the self-ref pin commit landed. At that tag the pipelines already declare `extraEnvSecretName` and pass `extra-env-secret-name` down to a `taskRef` still pinned to `v0.9.0` — and the task at `v0.9.0` does not declare that param. Tekton rejects a task param the task does not declare, so `pipelineRevision=v0.11.0` fails at resolution.

The **task** is correct at `v0.11.0` (it came in with #81); only the pipelines' outgoing refs are stale there.

Rather than force-move a published tag, this pins the whole ansible chain at `v0.11.1` and that commit gets tagged — so the pipelines and the task they call resolve to the same self-consistent tree.

`v0.11.0` is superseded: do not set `pipelineRevision` to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XW1BPvxyeuok5hoduEwG91