### PR TITLE
feat(packer): log in via AppRole when the vault secret has no token

### DIFF
--- a/pipelines/build-packer-template.yaml
+++ b/pipelines/build-packer-template.yaml
@@ -137,8 +137,9 @@ spec:
         params:
           - name: url
             value: https://github.com/stuttgart-things/stage-time.git
+          # TEST PIN -- must be a released tag before this merges.
           - name: revision
-            value: v0.9.0
+            value: feat/packer-approle-login
           - name: pathInRepo
             value: tasks/execute-packer.yaml
       workspaces:

--- a/pipelines/build-packer-template.yaml
+++ b/pipelines/build-packer-template.yaml
@@ -137,9 +137,8 @@ spec:
         params:
           - name: url
             value: https://github.com/stuttgart-things/stage-time.git
-          # TEST PIN -- must be a released tag before this merges.
           - name: revision
-            value: feat/packer-approle-login
+            value: v0.12.0
           - name: pathInRepo
             value: tasks/execute-packer.yaml
       workspaces:

--- a/tasks/execute-packer.yaml
+++ b/tasks/execute-packer.yaml
@@ -111,6 +111,13 @@ spec:
       description: name of the vault secret
       type: string
       default: "vault"
+    - name: vault-approle-auth-path
+      description: >-
+        auth mount path used for the AppRole login that runs when the vault
+        secret carries no VAULT_TOKEN. Vault allows the approle backend to be
+        mounted under any name, so this is a parameter rather than a constant.
+      type: string
+      default: "approle"
   results:
     - name: action-performed
       description: the packer action that was executed
@@ -280,6 +287,8 @@ spec:
               key: $(params.vault-secret-key-token)
               name: $(params.vault-secret-name)
               optional: true
+        - name: VAULT_APPROLE_PATH
+          value: $(params.vault-approle-auth-path)
       envFrom:
         - secretRef:
             name: $(params.credentials-secret-name)
@@ -295,6 +304,88 @@ spec:
         # results; the build branch overwrites template-name on success.
         printf '%s' "$(params.ACTION)" > "$(results.action-performed.path)"
         printf '' > "$(results.template-name.path)"
+
+        # AppRole login, when the vault secret carries no VAULT_TOKEN.
+        #
+        # packer's vault() template function builds a client from VAULT_ADDR +
+        # VAULT_TOKEN and never logs in itself, so a Vault that only hands out
+        # an AppRole used to force a long-lived token into the secret. Trading
+        # that for one obtained here removes the standing credential: the
+        # AppRole is scoped by its own policies, and the token is revoked when
+        # the step exits.
+        #
+        # The revoke is not cosmetic. The login inherits the ROLE's token_ttl,
+        # which on the labul infra Vault is 32 DAYS -- without an explicit
+        # revoke every build would leave behind a month-valid credential, which
+        # is the very thing this replaces. Vault has no "give me a 10-minute
+        # token" knob on the login call, so the trap is the mechanism.
+        #
+        # Only fires when VAULT_TOKEN is absent -- every existing secret that
+        # carries a token behaves exactly as before, so this is additive.
+        #
+        # The image has no vault CLI (checked on sthings-packer:2.0.0), hence
+        # curl + jq. The payload goes in over stdin rather than argv so the
+        # role/secret id never appear in the process table.
+        if [ -z "${VAULT_TOKEN:-}" ] && [ -n "${VAULT_ROLE_ID:-}" ] && [ -n "${VAULT_SECRET_ID:-}" ]; then
+          if [ -z "${VAULT_ADDR:-}" ]; then
+            echo "VAULT_ROLE_ID is set but VAULT_ADDR is empty - check the vault secret" >&2
+            exit 1
+          fi
+
+          echo "=========================================="
+          echo "VAULT APPROLE LOGIN"
+          echo "=========================================="
+          echo "VAULT_ADDR: ${VAULT_ADDR}"
+
+          # curl does not read SSL_CERT_FILE; point it at the same per-run
+          # bundle the trust-ca-certs step built, so a private-CA Vault works
+          # without --insecure.
+          CACERT_FLAG=""
+          if [ -s "${SSL_CERT_FILE:-}" ]; then
+            CACERT_FLAG="--cacert ${SSL_CERT_FILE}"
+          fi
+
+          # shellcheck disable=SC2086
+          LOGIN_RESPONSE=$(
+            jq -n --arg r "${VAULT_ROLE_ID}" --arg s "${VAULT_SECRET_ID}" \
+                 '{role_id: $r, secret_id: $s}' \
+            | curl -sS --max-time 30 ${CACERT_FLAG} \
+                   -X POST --data @- \
+                   "${VAULT_ADDR%/}/v1/auth/${VAULT_APPROLE_PATH:-approle}/login"
+          ) || {
+            echo "Vault login request failed (network/TLS) against ${VAULT_ADDR}" >&2
+            exit 1
+          }
+
+          VAULT_TOKEN=$(printf '%s' "${LOGIN_RESPONSE}" | jq -r '.auth.client_token // empty')
+          if [ -z "${VAULT_TOKEN}" ]; then
+            # .errors is Vault's own message and carries no credential material.
+            echo "Vault AppRole login failed: $(printf '%s' "${LOGIN_RESPONSE}" | jq -rc '.errors // "no token in response"')" >&2
+            exit 1
+          fi
+          export VAULT_TOKEN
+
+          # Revoke on the way out, whatever the outcome. `|| true` and the
+          # saved exit code keep the trap from rewriting the step's real
+          # result -- a failed revoke must not turn a failed build green, nor
+          # a green build red.
+          # shellcheck disable=SC2064,SC2086
+          trap 'rc=$?; curl -sS --max-time 10 '"${CACERT_FLAG}"' -X POST \
+                  -H "X-Vault-Token: ${VAULT_TOKEN}" \
+                  "${VAULT_ADDR%/}/v1/auth/token/revoke-self" >/dev/null 2>&1 \
+                  || echo "warning: could not revoke the Vault token" >&2; exit $rc' EXIT
+
+          # Echo the granted policies. Nearly every failure in this area is a
+          # token pointed at the wrong Vault or missing a path grant, and both
+          # are obvious from this one line -- it turns a confusing "permission
+          # denied" deep inside a 20-minute build into an up-front check.
+          # shellcheck disable=SC2086
+          printf 'token policies: %s\n' \
+            "$(curl -sS --max-time 15 ${CACERT_FLAG} \
+                    -H "X-Vault-Token: ${VAULT_TOKEN}" \
+                    "${VAULT_ADDR%/}/v1/auth/token/lookup-self" \
+               | jq -rc '.data.policies // "unknown"')"
+        fi
 
         # `packer init` first, in THIS container, so the plugins it installs
         # are visible to the validate/build below. ACTION=init always inits -


### PR DESCRIPTION
## Why

`packer`'s `vault()` template function builds its client from `VAULT_ADDR` + `VAULT_TOKEN` and never performs an AppRole login. A Vault that only issues an AppRole therefore forced a long-lived token into the pipeline's vault Secret.

That is what kept the LabUL Proxmox build off this path. Both credentials it needs live on the infra Vault — `cicd-proxmox-labul/data/default` for the PVE API, `ssh/data/sthings` for the base-os login password — and that Vault hands out the `cicd-secrets-reader` AppRole and nothing else.

## What

`execute-packer` logs in itself when `VAULT_TOKEN` is absent and `VAULT_ROLE_ID`/`VAULT_SECRET_ID` are present. Secrets that carry a token are untouched, so every existing vSphere build behaves exactly as before.

**The token is revoked in an `EXIT` trap, and that is load-bearing.** The login inherits the role's `token_ttl` — **32 days** on the labul infra Vault. Without the revoke, every build would leave a month-valid credential behind, which is precisely what this is meant to remove. Vault has no per-login TTL knob, so the trap is the mechanism.

Smaller decisions:

- **curl + jq, not the vault CLI** — `sthings-packer:2.0.0` ships no `vault` binary (checked).
- the login payload goes in over **stdin**, so the role/secret id never reach `argv`.
- **`--cacert` passed explicitly** — curl does not read `SSL_CERT_FILE`, so a private-CA Vault keeps working without `--insecure`.
- **the granted policies are echoed.** Almost every failure in this area is a token aimed at the wrong Vault or missing a grant; both become visible up front instead of as a denial deep inside a 20-minute build.
- the approle auth mount is a param (`vault-approle-auth-path`) — Vault lets that backend be mounted under any name.

## Verification

Run in the real build image against the live infra Vault, six states:

| State | Expected | Result |
|---|---|---|
| AppRole set, no token | login, policies echoed | exit 0, `["default","read-cicd","read-ssh-sthings"]` |
| `VAULT_TOKEN` already set | block skipped | exit 0, no login |
| wrong secret id | clear error | exit 1, `["invalid role or secret ID"]` |
| `VAULT_ADDR` empty | clear error | exit 1 |
| neither credential | no-op (today's vSphere path) | exit 0 |
| unreachable host | clean network/TLS error | exit 1 |

Plus a subshell run to prove the trap: after the step exits, `lookup-self` with that token returns **HTTP 403**.

## Related

- stuttgart-things/stuttgart-things#2459 — the `vault-infra` Secret this enables
- stuttgart-things/stuttgart-things#2442 — whose premise ("no CI path for Proxmox builds because two Vaults are needed") turns out not to hold

## Proven end to end on kind1

The LabUL Proxmox u26 base-OS build ran through the `PackerBuild` XR against the infra Vault and produced a template — the first time that build has run outside an operator's shell.

```
VAULT APPROLE LOGIN
VAULT_ADDR: https://vault.infra.sthings-vsphere.labul.sva.de
token policies: ["default","read-cicd","read-ssh-sthings"]
…
==> proxmox-iso.ubuntu26_base: Uploaded ISO to DD-sthings:iso/…   <- vault() resolved, PVE API accepted
…
TASK [sthings.baseos.create_os_user : User creation]              <- reads ssh/data/sthings
PLAY RECAP: ok=57  changed=19  unreachable=0  failed=0  ignored=0
--> A template was created: 211
```

Both consumers served from one Vault by one AppRole login. 35 minutes, `PackerBuild` `Ready=True`.

The branch pin used for that run has been replaced with `v0.12.0`; the net change to `build-packer-template.yaml` is the one-line self-ref bump.
