### PR TITLE
fix(promote): fetch the branch before --force-with-lease, or a re-run dies

### DIFF
--- a/pipelines/promote-proxmox-template.yaml
+++ b/pipelines/promote-proxmox-template.yaml
@@ -116,7 +116,7 @@ spec:
           # an unpinned default silently changes what runs. Bump alongside the
           # task. Must be a tag that CONTAINS tasks/promote-config-pr.yaml.
           - name: revision
-            value: v0.13.0
+            value: v0.13.1
           - name: pathInRepo
             value: tasks/promote-config-pr.yaml
       workspaces:

--- a/tasks/promote-config-pr.yaml
+++ b/tasks/promote-config-pr.yaml
@@ -365,6 +365,22 @@ spec:
           exit 0
         fi
 
+        # Fetch the branch into its remote-tracking ref BEFORE pushing.
+        #
+        # --force-with-lease compares what we believe origin/<branch> to be
+        # against what it actually is, and refuses when we have no belief at
+        # all. A --depth 1 clone of the base branch has never heard of this one,
+        # so on a re-run -- when the branch DOES exist remotely -- the push dies
+        # with "stale info" and the whole promotion fails. The first run passes
+        # because there is nothing to overwrite, which is exactly why this hid
+        # until the second one.
+        #
+        # `|| true`: on a first promotion the ref does not exist remotely and
+        # the fetch is expected to fail. The lease is then vacuous, correctly so
+        # -- there is nothing to clobber.
+        git fetch --quiet --depth 1 origin \
+          "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}" 2>/dev/null || true
+
         git push -q --force-with-lease origin "${BRANCH}"
         echo "pushed ${BRANCH}"
 


### PR DESCRIPTION
Found by running the promote pipeline twice with identical parameters against the real repo — the only place it shows.

```
! [rejected]  promote/environments-labul-templateVmId-999 (stale info)
error: failed to push some refs
```

`--force-with-lease` compares what we believe `origin/<branch>` to be against what it actually is, and **refuses when we have no belief at all**. The clone is `--depth 1` of the base branch, so it has never heard of the promotion branch. First run: nothing remote, push succeeds. Second run: the branch exists, the lease has nothing to compare against, git rejects.

That is exactly the case the deterministic branch name exists to serve — a re-run should update its own open PR instead of opening a second one — so **the reuse path was broken by the safety mechanism protecting it**. A `PackerRelease` reconciles repeatedly, so in practice every promotion after the first would have failed.

Fix: fetch the branch into its remote-tracking ref before pushing, which makes the lease meaningful rather than vacuous. `|| true` because on a first promotion the ref genuinely does not exist remotely.

The local six-state test could not catch this — it ran against a `file://` clone with no pre-existing remote branch. Verified on kind1 after the fix.

Pipeline self-ref bumped to `v0.13.1`.